### PR TITLE
Extend tests for cubic geometry

### DIFF
--- a/tests/classical_test.py
+++ b/tests/classical_test.py
@@ -279,6 +279,109 @@ def out_hex_brbound(nodes_hex_brbound):
     return expected_output
 
 
+# cubic boundary condition fixtures
+@pytest.fixture
+def nodes_cb_rbound():
+    nodes = np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic + 2))
+    nodes[-1, 1, 1, 0] = 1  # particle crossing +x
+    nodes[-1, 1, 1, 6] = 1  # rest ref
+    nodes[0, 1, 1, 0] = 1  # moving reference
+    return nodes
+
+
+@pytest.fixture
+def out_cb_rbound(nodes_cb_rbound):
+    expected_output = np.zeros(nodes_cb_rbound.shape)
+    expected_output[-1, 1, 1, 6] = 1
+    expected_output[1, 1, 1, 0] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_cb_lbound():
+    nodes = np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic + 2))
+    nodes[0, 1, 1, 1] = 1
+    nodes[0, 1, 1, 6] = 1
+    nodes[2, 1, 1, 1] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_cb_lbound(nodes_cb_lbound):
+    expected_output = np.zeros(nodes_cb_lbound.shape)
+    expected_output[0, 1, 1, 6] = 1
+    expected_output[1, 1, 1, 1] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_cb_tbound():
+    nodes = np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic + 2))
+    nodes[1, -1, 1, 2] = 1
+    nodes[1, -1, 1, 6] = 1
+    nodes[1, 0, 1, 2] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_cb_tbound(nodes_cb_tbound):
+    expected_output = np.zeros(nodes_cb_tbound.shape)
+    expected_output[1, -1, 1, 6] = 1
+    expected_output[1, 1, 1, 2] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_cb_bbound():
+    nodes = np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic + 2))
+    nodes[1, 0, 1, 3] = 1
+    nodes[1, 0, 1, 6] = 1
+    nodes[1, 2, 1, 3] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_cb_bbound(nodes_cb_bbound):
+    expected_output = np.zeros(nodes_cb_bbound.shape)
+    expected_output[1, 0, 1, 6] = 1
+    expected_output[1, 1, 1, 3] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_cb_ubound():
+    nodes = np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic + 2))
+    nodes[1, 1, -1, 4] = 1
+    nodes[1, 1, -1, 6] = 1
+    nodes[1, 1, 0, 4] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_cb_ubound(nodes_cb_ubound):
+    expected_output = np.zeros(nodes_cb_ubound.shape)
+    expected_output[1, 1, -1, 6] = 1
+    expected_output[1, 1, 1, 4] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_cb_dbound():
+    nodes = np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic + 2))
+    nodes[1, 1, 0, 5] = 1
+    nodes[1, 1, 0, 6] = 1
+    nodes[1, 1, 2, 5] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_cb_dbound(nodes_cb_dbound):
+    expected_output = np.zeros(nodes_cb_dbound.shape)
+    expected_output[1, 1, 0, 6] = 1
+    expected_output[1, 1, 1, 5] = 1
+    return expected_output
+
+
 class Test_LGCA_classical(T_LGCA_Common):
     """
     Class for testing classical LGCA (volume exclusion, not identity-based).
@@ -295,7 +398,8 @@ class Test_LGCA_classical(T_LGCA_Common):
     @pytest.mark.parametrize("geom,dims", [
         ('lin', (com.xdim_1d,)),
         ('square', (com.xdim_square, com.ydim_square)),
-        ('hex', (com.xdim_hex, com.ydim_hex))
+        ('hex', (com.xdim_hex, com.ydim_hex)),
+        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
     ])
     def test_recording(self, geom, dims):
         # timeevo and recording: check if all properties are available when requested
@@ -372,6 +476,20 @@ class Test_LGCA_classical(T_LGCA_Common):
         expected_output = np.zeros((self.xdim_hex, self.ydim_hex, restchannels + self.b_hex))
         expected_output[1, 1, 0:7] = 1
         self.t_propagation_template('hex', nodes, expected_output)
+
+        # 3D cubic
+        restchannels = 2
+        nodes = np.zeros((self.xdim_cubic, self.ydim_cubic, self.zdim_cubic, restchannels + self.b_cubic))
+        nodes[0, 1, 1, 0] = 1  # +x
+        nodes[2, 1, 1, 1] = 1  # -x
+        nodes[1, 0, 1, 2] = 1  # +y
+        nodes[1, 2, 1, 3] = 1  # -y
+        nodes[1, 1, 0, 4] = 1  # +z
+        nodes[1, 1, 2, 5] = 1  # -z
+        nodes[1, 1, 1, 6] = 1  # rest
+        expected_output = np.zeros((self.xdim_cubic, self.ydim_cubic, self.zdim_cubic, restchannels + self.b_cubic))
+        expected_output[1, 1, 1, 0:7] = 1
+        self.t_propagation_template('cubic', nodes, expected_output)
 
     def test_pbc_1d(self, nodes_1d_rbound, out_1d_rbound, nodes_1d_lbound, out_1d_lbound):
         # check periodic boundary conditions in 1D
@@ -548,10 +666,53 @@ class Test_LGCA_classical(T_LGCA_Common):
         # bottom right boundary
         self.t_propagation_template('hex', nodes_hex_brbound, out_hex_brbound, bc='abc')
 
+    def test_pbc_cubic(self, nodes_cb_rbound, out_cb_rbound, nodes_cb_lbound, out_cb_lbound,
+                       nodes_cb_tbound, out_cb_tbound, nodes_cb_bbound, out_cb_bbound,
+                       nodes_cb_ubound, out_cb_ubound, nodes_cb_dbound, out_cb_dbound):
+        out_cb_rbound[0, 1, 1, 0] = 1
+        out_cb_lbound[-1, 1, 1, 1] = 1
+        out_cb_tbound[1, 0, 1, 2] = 1
+        out_cb_bbound[1, -1, 1, 3] = 1
+        out_cb_ubound[1, 1, 0, 4] = 1
+        out_cb_dbound[1, 1, 2, 5] = 1
+        self.t_propagation_template('cubic', nodes_cb_rbound, out_cb_rbound, bc='pbc')
+        self.t_propagation_template('cubic', nodes_cb_lbound, out_cb_lbound, bc='pbc')
+        self.t_propagation_template('cubic', nodes_cb_tbound, out_cb_tbound, bc='pbc')
+        self.t_propagation_template('cubic', nodes_cb_bbound, out_cb_bbound, bc='pbc')
+        self.t_propagation_template('cubic', nodes_cb_ubound, out_cb_ubound, bc='pbc')
+        self.t_propagation_template('cubic', nodes_cb_dbound, out_cb_dbound, bc='pbc')
+
+    def test_rbc_cubic(self, nodes_cb_rbound, out_cb_rbound, nodes_cb_lbound, out_cb_lbound,
+                       nodes_cb_tbound, out_cb_tbound, nodes_cb_bbound, out_cb_bbound,
+                       nodes_cb_ubound, out_cb_ubound, nodes_cb_dbound, out_cb_dbound):
+        out_cb_rbound[-1, 1, 1, 1] = 1
+        out_cb_lbound[0, 1, 1, 0] = 1
+        out_cb_tbound[1, -1, 1, 3] = 1
+        out_cb_bbound[1, 0, 1, 2] = 1
+        out_cb_ubound[1, 1, -1, 5] = 1
+        out_cb_dbound[1, 1, 0, 4] = 1
+        self.t_propagation_template('cubic', nodes_cb_rbound, out_cb_rbound, bc='rbc')
+        self.t_propagation_template('cubic', nodes_cb_lbound, out_cb_lbound, bc='rbc')
+        self.t_propagation_template('cubic', nodes_cb_tbound, out_cb_tbound, bc='rbc')
+        self.t_propagation_template('cubic', nodes_cb_bbound, out_cb_bbound, bc='rbc')
+        self.t_propagation_template('cubic', nodes_cb_ubound, out_cb_ubound, bc='rbc')
+        self.t_propagation_template('cubic', nodes_cb_dbound, out_cb_dbound, bc='rbc')
+
+    def test_abc_cubic(self, nodes_cb_rbound, out_cb_rbound, nodes_cb_lbound, out_cb_lbound,
+                       nodes_cb_tbound, out_cb_tbound, nodes_cb_bbound, out_cb_bbound,
+                       nodes_cb_ubound, out_cb_ubound, nodes_cb_dbound, out_cb_dbound):
+        self.t_propagation_template('cubic', nodes_cb_rbound, out_cb_rbound, bc='abc')
+        self.t_propagation_template('cubic', nodes_cb_lbound, out_cb_lbound, bc='abc')
+        self.t_propagation_template('cubic', nodes_cb_tbound, out_cb_tbound, bc='abc')
+        self.t_propagation_template('cubic', nodes_cb_bbound, out_cb_bbound, bc='abc')
+        self.t_propagation_template('cubic', nodes_cb_ubound, out_cb_ubound, bc='abc')
+        self.t_propagation_template('cubic', nodes_cb_dbound, out_cb_dbound, bc='abc')
+
     @pytest.mark.parametrize("geom,nodes", [
         ('lin', com.nodes_ve_1d),
         ('square', com.nodes_ve_square),
-        ('hex', com.nodes_ve_hex)
+        ('hex', com.nodes_ve_hex),
+        ('cubic', com.nodes_ve_cubic)
     ])
     def test_characteristics(self, geom, nodes):
         # test compliance in all interactions to:

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -36,6 +36,11 @@ class T_LGCA_Common(ABC):
     b_hex = 6
     xdim_hex = 4
     ydim_hex = 6
+    # 3D cubic
+    b_cubic = 6
+    xdim_cubic = 3
+    ydim_cubic = 3
+    zdim_cubic = 3
 
     # classical parameters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # 1D
@@ -53,6 +58,11 @@ class T_LGCA_Common(ABC):
     K_ve_hex = b_hex + restchannels_ve_hex
     nodes_ve_hex = rng.integers(low=0, high=1, endpoint=True,
                                 size=(xdim_hex, ydim_hex, b_hex + restchannels_ve_hex))
+    # 3D cubic
+    restchannels_ve_cubic = 2
+    K_ve_cubic = b_cubic + restchannels_ve_cubic
+    nodes_ve_cubic = rng.integers(low=0, high=1, endpoint=True,
+                                  size=(xdim_cubic, ydim_cubic, zdim_cubic, b_cubic + restchannels_ve_cubic))
 
     # ib parameters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # reuses some classical parameters
@@ -77,6 +87,15 @@ class T_LGCA_Common(ABC):
                                                                        (b_hex + restchannels_ve_hex) - no_particles_hex))
     rng.shuffle(nodes_ib_hex)
     nodes_ib_hex = nodes_ib_hex.reshape((xdim_hex, ydim_hex, b_hex + restchannels_ve_hex))
+    # 3D cubic
+    no_particles_cubic = rng.integers(low=1, high=(xdim_cubic * ydim_cubic * zdim_cubic *
+                                                    (b_cubic + restchannels_ve_cubic)), endpoint=True, size=1)
+    nodes_ib_cubic = np.append(np.arange(no_particles_cubic) + 1,
+                               np.zeros(xdim_cubic * ydim_cubic * zdim_cubic *
+                                         (b_cubic + restchannels_ve_cubic) - no_particles_cubic))
+    rng.shuffle(nodes_ib_cubic)
+    nodes_ib_cubic = nodes_ib_cubic.reshape((xdim_cubic, ydim_cubic, zdim_cubic,
+                                            b_cubic + restchannels_ve_cubic))
 
     # nove parameters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # nodes must be defined in the correct size! Maximum size of last dimension = b+1
@@ -94,7 +113,12 @@ class T_LGCA_Common(ABC):
     restchannels_nove_hex = restchannels_nove_square
     capacity_nove_hex = 8
     nodes_nove_hex = rng.integers(low=0, high=int(1.5 * capacity_nove_hex),
-                                      size=(xdim_hex, ydim_hex, b_hex + 1), endpoint=True)
+                                  size=(xdim_hex, ydim_hex, b_hex + 1), endpoint=True)
+    # 3D cubic
+    restchannels_nove_cubic = 2
+    capacity_nove_cubic = 8
+    nodes_nove_cubic = rng.integers(low=0, high=int(1.5 * capacity_nove_cubic),
+                                    size=(xdim_cubic, ydim_cubic, zdim_cubic, b_cubic + 1), endpoint=True)
 
     def t_propagation_template(self, geom, nodes, expected_output, bc='pbc'):
         # check that propagation and rest channels work: all particles should move into one node within one timestep
@@ -142,16 +166,19 @@ class Test_LGCA_General:
         ('lin',     True, False, com.nodes_ve_1d,       (com.xdim_1d,),                     com.restchannels_ve_1d),
         ('square',  True, False, com.nodes_ve_square,   (com.xdim_square, com.ydim_square), com.restchannels_ve_square),
         ('hex',     True, False, com.nodes_ve_hex,      (com.xdim_hex, com.ydim_hex),       com.restchannels_ve_hex),
+        ('cubic',   True, False, com.nodes_ve_cubic,    (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_ve_cubic),
         # IBLGCA (ve, ib)
         # (geom,    ve,   ib,   nodes,                  dims,                               restchannels)
         ('lin',     True, True, com.nodes_ib_1d,        (com.xdim_1d,),                     com.restchannels_ve_1d),
         ('square',  True, True, com.nodes_ib_square,    (com.xdim_square, com.ydim_square), com.restchannels_ve_square),
         ('hex',     True, True, com.nodes_ib_hex,       (com.xdim_hex, com.ydim_hex),       com.restchannels_ve_hex),
+        ('cubic',   True, True, com.nodes_ib_cubic,     (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_ve_cubic),
         # NoVE_LGCA (nove, non-ib)
         # (geom,    ve,    ib,    nodes,                    dims,                               restchannels)
         ('lin',     False, False, com.nodes_nove_1d,        (com.xdim_1d,),                     1),
         ('square',  False, False, com.nodes_nove_square,    (com.xdim_square, com.ydim_square), 1),
-        ('hex',     False, False, com.nodes_nove_hex,       (com.xdim_hex, com.ydim_hex),       1)
+        ('hex',     False, False, com.nodes_nove_hex,       (com.xdim_hex, com.ydim_hex),       1),
+        ('cubic',   False, False, com.nodes_nove_cubic,     (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), 1)
     ])
     def test_getlgca_lattice_setup_nodes(self, geom, ve, ib, nodes, dims, restchannels):
         # 'node' keyword check: provided lattice is adopted by LGCA
@@ -187,16 +214,19 @@ class Test_LGCA_General:
         ('lin',     True, (com.xdim_1d,),                     com.restchannels_ve_1d,        density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_1d, K=com.K_ve_1d)),
         ('square',  True, (com.xdim_square, com.ydim_square), com.restchannels_ve_square,    density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_square, K=com.K_ve_square)),
         ('hex',     True, (com.xdim_hex, com.ydim_hex),       com.restchannels_ve_hex,       density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_hex, K=com.K_ve_hex)),
+        ('cubic',   True, (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_ve_cubic, density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_cubic, K=com.K_ve_cubic)),
         # NoVE_LGCA (nove, non-ib)
         # written assuming that capacity for nove is set to velocitychannels + restchannels
         # (geom,    ve,    dims,                               restchannels,                 density,        init_particles)
         ('lin',     False, (com.xdim_1d,),                     com.restchannels_nove_1d,     density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_1d, b=com.b_1d)),
         ('square',  False, (com.xdim_square, com.ydim_square), com.restchannels_nove_square, density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_square, b=com.b_square)),
         ('hex',     False, (com.xdim_hex, com.ydim_hex),       com.restchannels_nove_hex,    density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_hex, b=com.b_hex)),
+        ('cubic',   False, (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_nove_cubic, density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_cubic, b=com.b_cubic)),
         # (geom,    ve,    dims,                               restchannels,                 density,        init_particles)
         ('lin',     False, (com.xdim_1d,),                     com.restchannels_nove_1d,     density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_1d, b=com.b_1d)),
         ('square',  False, (com.xdim_square, com.ydim_square), com.restchannels_nove_square, density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_square, b=com.b_square)),
         ('hex',     False, (com.xdim_hex, com.ydim_hex),       com.restchannels_nove_hex,    density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_hex, b=com.b_hex))
+        ,('cubic',   False, (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_nove_cubic,    density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_cubic, b=com.b_cubic))
     ])
     def test_getlgca_lattice_setup_homogeneous(self, geom, ve, dims, restchannels, density, init_particles):
         # 'hom', 'density' keyword check
@@ -221,21 +251,25 @@ class Test_LGCA_General:
         ('lin',     True, False, (400,),        com.restchannels_ve_1d,        density_ve, com.K_ve_1d),
         ('square',  True, False, (20, 20),      com.restchannels_ve_square,    density_ve, com.K_ve_square),
         ('hex',     True, False, (20, 20),      com.restchannels_ve_hex,       density_ve, com.K_ve_hex),
+        ('cubic',   True, False, (5, 5, 5),     com.restchannels_ve_cubic,    density_ve, com.K_ve_cubic),
         # IBLGCA (ve, ib)
         # (geom,    ve,   ib,   dims_large,    restchannels,                density,    capacity)
         ('lin',     True, True, (400,),        com.restchannels_ve_1d,      density_ve, com.K_ve_1d),
         ('square',  True, True, (20, 20),      com.restchannels_ve_square,  density_ve, com.K_ve_square),
         ('hex',     True, True, (20, 20),      com.restchannels_ve_hex,     density_ve, com.K_ve_hex),
+        ('cubic',   True, True, (5, 5, 5),     com.restchannels_ve_cubic,   density_ve, com.K_ve_cubic),
         # NoVE_LGCA (nove, non-ib)
         # written assuming that capacity for nove is set to velocitychannels + restchannels
         # (geom,   ve,    ib,    dims_large,   restchannels,                 density,        capacity)
         ('lin',    False, False, (400,),       com.restchannels_nove_1d,     density_nove_1, com.b_1d+com.restchannels_nove_1d),
         ('square', False, False, (20, 20),     com.restchannels_nove_square, density_nove_1, com.b_square+com.restchannels_nove_square),
         ('hex',    False, False, (20, 20),     com.restchannels_nove_hex,    density_nove_1, com.b_hex+com.restchannels_nove_hex),
+        ('cubic',  False, False, (5, 5, 5),    com.restchannels_nove_cubic, density_nove_1, com.b_cubic+com.restchannels_nove_cubic),
         # (geom,   ve,    ib,    dims_large,   restchannels,                 density,        capacity)
         ('lin',    False, False, (400,),       com.restchannels_nove_1d,     density_nove_2, com.b_1d+com.restchannels_nove_1d),
         ('square', False, False, (20, 20),     com.restchannels_nove_square, density_nove_2, com.b_square+com.restchannels_nove_square),
         ('hex',    False, False, (20, 20),     com.restchannels_nove_hex,    density_nove_2, com.b_hex+com.restchannels_nove_hex)
+        ,('cubic', False, False, (5, 5, 5),    com.restchannels_nove_cubic, density_nove_2, com.b_cubic+com.restchannels_nove_cubic)
     ])
     def test_getlgca_lattice_setup_random(self, geom, ve, ib, dims_large, restchannels, density, capacity):
         # 'density' keyword check, random reset

--- a/tests/ib_test.py
+++ b/tests/ib_test.py
@@ -25,8 +25,11 @@ from tests.common_test import T_LGCA_Common
 from tests.nove_test import Test_LGCA_NoVE as T_LGCA_NoVE  # rename to avoid duplicate execution of these tests
 from tests.classical_test import Test_LGCA_classical as T_LGCA_classical
 import tests.nove_test
+import tests.classical_test
 matching_import("^nodes_", tests.nove_test, globals())
 matching_import("^out_", tests.nove_test, globals())
+matching_import("^nodes_cb_", tests.classical_test, globals())
+matching_import("^out_cb_", tests.classical_test, globals())
 
 com = T_LGCA_Common
 
@@ -54,11 +57,15 @@ class Test_LGCA_IB(T_LGCA_Common):
     test_rbc_square = T_LGCA_NoVE.test_rbc_square
     test_pbc_hex = T_LGCA_NoVE.test_pbc_hex
     test_rbc_hex = T_LGCA_NoVE.test_rbc_hex
+    test_pbc_cubic = T_LGCA_classical.test_pbc_cubic
+    test_rbc_cubic = T_LGCA_classical.test_rbc_cubic
+    test_abc_cubic = T_LGCA_classical.test_abc_cubic
 
     @pytest.mark.parametrize("geom,dims", [
         ('lin', (com.xdim_1d,)),
         ('square', (com.xdim_square, com.ydim_square)),
-        ('hex', (com.xdim_hex, com.ydim_hex))
+        ('hex', (com.xdim_hex, com.ydim_hex)),
+        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
     ])
     def test_recording(self, geom, dims):
         # timeevo and recording: check if all properties are available when requested
@@ -140,10 +147,31 @@ class Test_LGCA_IB(T_LGCA_Common):
         expected_output[1, 1, 6] = 7  # particle resting
         self.t_propagation_template('hex', nodes, expected_output)
 
+        # 3D cubic
+        restchannels = 2
+        nodes = np.zeros((self.xdim_cubic, self.ydim_cubic, self.zdim_cubic, self.b_cubic + restchannels))
+        nodes[0, 1, 1, 0] = 1
+        nodes[2, 1, 1, 1] = 2
+        nodes[1, 0, 1, 2] = 3
+        nodes[1, 2, 1, 3] = 4
+        nodes[1, 1, 0, 4] = 5
+        nodes[1, 1, 2, 5] = 6
+        nodes[1, 1, 1, 6] = 7
+        expected_output = np.zeros((self.xdim_cubic, self.ydim_cubic, self.zdim_cubic, self.b_cubic + restchannels))
+        expected_output[1, 1, 1, 0] = 1
+        expected_output[1, 1, 1, 1] = 2
+        expected_output[1, 1, 1, 2] = 3
+        expected_output[1, 1, 1, 3] = 4
+        expected_output[1, 1, 1, 4] = 5
+        expected_output[1, 1, 1, 5] = 6
+        expected_output[1, 1, 1, 6] = 7
+        self.t_propagation_template('cubic', nodes, expected_output)
+
     @pytest.mark.parametrize("geom,nodes", [
         ('lin', com.nodes_ib_1d),
         ('square', com.nodes_ib_square),
-        ('hex', com.nodes_ib_hex)
+        ('hex', com.nodes_ib_hex),
+        ('cubic', com.nodes_ib_cubic)
     ])
     def test_characteristics(self, geom, nodes):
         # test compliance in all interactions to:

--- a/tests/nove_ib_test.py
+++ b/tests/nove_ib_test.py
@@ -7,6 +7,10 @@ pytest.importorskip("numba")
 from lgca import get_lgca
 from tests.common_test import T_LGCA_Common
 from tests.classical_test import Test_LGCA_classical as T_LGCA_classical
+import tests.classical_test
+from tests.ib_test import matching_import
+matching_import("^nodes_cb_", tests.classical_test, globals())
+matching_import("^out_cb_", tests.classical_test, globals())
 
 
 def counts_to_lists(arr):
@@ -240,6 +244,9 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
     test_abc_1d = T_LGCA_classical.test_abc_1d
     test_abc_square = T_LGCA_classical.test_abc_square
     test_abc_hex = T_LGCA_classical.test_abc_hex
+    test_pbc_cubic = T_LGCA_classical.test_pbc_cubic
+    test_rbc_cubic = T_LGCA_classical.test_rbc_cubic
+    test_abc_cubic = T_LGCA_classical.test_abc_cubic
 
     def t_prop_counts_template(self, geom, nodes, expected, bc="pbc"):
         nodes_ib = counts_to_lists(nodes)
@@ -260,7 +267,8 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
     @pytest.mark.parametrize("geom,dims", [
         ("lin", (com.xdim_1d,)),
         ("square", (com.xdim_square, com.ydim_square)),
-        ("hex", (com.xdim_hex, com.ydim_hex))
+        ("hex", (com.xdim_hex, com.ydim_hex)),
+        ("cubic", (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
     ])
     def test_recording(self, geom, dims):
         lgca_1 = get_lgca(geometry=geom, ve=False, ib=True, dims=dims, density=0.5, interaction="only_propagation")
@@ -348,7 +356,8 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
     @pytest.mark.parametrize("geom,nodes,b", [
         ("lin", com.nodes_nove_1d, com.b_1d),
         ("square", com.nodes_nove_square, com.b_square),
-        ("hex", com.nodes_nove_hex, com.b_hex)
+        ("hex", com.nodes_nove_hex, com.b_hex),
+        ("cubic", com.nodes_nove_cubic, com.b_cubic)
     ])
     def test_getlgca_capacity(self, geom, nodes, b):
         capacity = 10
@@ -372,7 +381,8 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
     @pytest.mark.parametrize("geom,nodes", [
         ("lin", com.nodes_nove_1d),
         ("square", com.nodes_nove_square),
-        ("hex", com.nodes_nove_hex)
+        ("hex", com.nodes_nove_hex),
+        ("cubic", com.nodes_nove_cubic)
     ])
     def test_characteristics(self, geom, nodes):
         nodes_ib = counts_to_lists(nodes)

--- a/tests/nove_test.py
+++ b/tests/nove_test.py
@@ -317,11 +317,15 @@ class Test_LGCA_NoVE(T_LGCA_Common):
     test_abc_1d = T_LGCA_classical.test_abc_1d
     test_abc_square = T_LGCA_classical.test_abc_square
     test_abc_hex = T_LGCA_classical.test_abc_hex
+    test_pbc_cubic = T_LGCA_classical.test_pbc_cubic
+    test_rbc_cubic = T_LGCA_classical.test_rbc_cubic
+    test_abc_cubic = T_LGCA_classical.test_abc_cubic
 
     @pytest.mark.parametrize("geom,dims", [
         ('lin', (com.xdim_1d,)),
         ('square', (com.xdim_square, com.ydim_square)),
-        ('hex', (com.xdim_hex, com.ydim_hex))
+        ('hex', (com.xdim_hex, com.ydim_hex)),
+        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
     ])
     def test_recording(self, geom, dims):
         # timeevo and recording: check if all properties are available when requested
@@ -418,7 +422,8 @@ class Test_LGCA_NoVE(T_LGCA_Common):
     @pytest.mark.parametrize("geom,nodes,b", [
         ('lin', com.nodes_nove_1d, com.b_1d),
         ('square', com.nodes_nove_square, com.b_square),
-        ('hex', com.nodes_nove_hex, com.b_hex)
+        ('hex', com.nodes_nove_hex, com.b_hex),
+        ('cubic', com.nodes_nove_cubic, com.b_cubic)
     ])
     def test_getlgca_capacity(self, geom, nodes, b):
         # lattice setup test with capacity: capacity defines how density is calculated
@@ -443,7 +448,8 @@ class Test_LGCA_NoVE(T_LGCA_Common):
     @pytest.mark.parametrize("geom,nodes", [
         ('lin', com.nodes_nove_1d),
         ('square', com.nodes_nove_square),
-        ('hex', com.nodes_nove_hex)
+        ('hex', com.nodes_nove_hex),
+        ('cubic', com.nodes_nove_cubic)
     ])
     @pytest.mark.skip(reason="unstable with missing numba")
     def test_characteristics(self, geom, nodes):


### PR DESCRIPTION
## Summary
- add cubic lattice constants and node arrays in `common_test.py`
- parameterize tests to include `cubic` geometry
- add fixtures and boundary tests for cubic lattices

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'lgca')*

------
https://chatgpt.com/codex/tasks/task_e_68447858953083338e86f5e861ebb8d4