### PR TITLE
Feat optional plotting requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Clone the repository and install the core requirements:
 git clone https://github.com/sisyga/biolgca.git
 cd biolgca
 pip install -r requirements.txt
+# install extra packages for plotting support
+pip install -r plotting-requirements.txt
 ```
 Run a short simulation to verify the setup:
 ```python
@@ -115,10 +117,10 @@ lgca.plot_prop_spatial(propname='r_b')  # plot on the right
 
 # Getting started
 #### Dependencies
-`biolgca` heavily depends on `numpy` and `matplotlib`. To install all dependencies 
-for using the package, run this from a command line:
-```python
-pip install matplotlib==3.3.2 numpy scipy sympy
+`biolgca` depends only on `numpy` for running simulations. To enable plotting
+features, install the optional dependencies:
+```bash
+pip install -r plotting-requirements.txt
 ```
 (On Windows, a terminal that understands `pip` out of the box can be opened in Anaconda in the 
 "Environments" tab, clicking on the triangle next to the environment's name.)

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,8 @@ Clone the repository and install the core requirements:
 git clone https://github.com/sisyga/biolgca.git
 cd biolgca
 pip install -r requirements.txt
+# install extra packages for plotting support
+pip install -r plotting-requirements.txt
 ```
 Run a short simulation to verify the setup:
 ```python
@@ -115,10 +117,10 @@ lgca.plot_prop_spatial(propname='r_b')  # plot on the right
 
 # Getting started
 #### Dependencies
-`biolgca` heavily depends on `numpy` and `matplotlib`. To install all dependencies 
-for using the package, run this from a command line:
-```python
-pip install matplotlib==3.3.2 numpy scipy sympy
+`biolgca` depends only on `numpy` for running simulations. To enable plotting
+features, install the optional dependencies:
+```bash
+pip install -r plotting-requirements.txt
 ```
 (On Windows, a terminal that understands `pip` out of the box can be opened in Anaconda in the 
 "Environments" tab, clicking on the triangle next to the environment's name.)

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -6,10 +6,10 @@ documentation yourself.  More detailed usage examples can be found in the
 :doc:`examples` section.
 ..  # Getting started
     #### Dependencies
-    `biolgca` heavily depends on `numpy` and `matplotlib`. To install all dependencies 
-    for using the package, run this from a command line:
-    ```python
-    pip install matplotlib==3.3.2 numpy scipy sympy
+    `biolgca` depends only on `numpy` for running simulations. To enable plotting
+    features, install the optional dependencies:
+    ```bash
+    pip install -r plotting-requirements.txt
     ```
     (On Windows, a terminal that understands `pip` out of the box can be opened in Anaconda in the 
     "Environments" tab, clicking on the triangle next to the environment's name.)

--- a/lgca/base.py
+++ b/lgca/base.py
@@ -20,11 +20,26 @@ import warnings
 from abc import ABC, abstractmethod
 from copy import copy, deepcopy
 
-import matplotlib.colors as colors
+
+class _MissingPlotLib:
+    """Placeholder object for an optional plotting library."""
+
+    def __init__(self, name: str):
+        self._name = name
+
+    def __getattr__(self, _):
+        raise ImportError(
+            f"Plotting requires {self._name}. Install extras with 'pip install -r plotting-requirements.txt'."
+        )
+
+
 import numpy as np
-from matplotlib import cm
-from matplotlib import pyplot as plt
-from matplotlib.cm import ScalarMappable
+try:  # optional plotting dependencies
+    import matplotlib.colors as colors
+    from matplotlib import cm, pyplot as plt
+    from matplotlib.cm import ScalarMappable
+except ImportError:  # pragma: no cover - handled at runtime
+    colors = cm = plt = ScalarMappable = _MissingPlotLib("matplotlib")
 from numpy import random as npr
 from sympy.utilities.iterables import multiset_permutations
 from tqdm.auto import tqdm

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -1,8 +1,9 @@
 from lgca.base import *
-from mayavi import mlab
-from mayavi import mlab
-
-from lgca.base import *
+try:  # optional plotting dependency
+    from mayavi import mlab
+except ImportError:  # pragma: no cover - handled at runtime
+    from lgca.base import _MissingPlotLib
+    mlab = _MissingPlotLib("mayavi")
 
 
 class LGCA_Cubic(LGCA_base):

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -17,15 +17,24 @@ Supported LGCA types:
 - identity-based LGCA without volume exclusion (:py:class:`NoVE_IBLGCA_Square`)
 """
 
-import matplotlib.animation as animation
-import matplotlib.colors as colors
-import matplotlib.ticker as mticker
 import numpy as np
-from matplotlib.collections import PatchCollection
-from matplotlib.colors import Normalize
-from matplotlib.patches import RegularPolygon, Circle, FancyArrowPatch
-from matplotlib import cm
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+try:  # optional plotting dependencies
+    import matplotlib.animation as animation
+    import matplotlib.colors as colors
+    import matplotlib.ticker as mticker
+    from matplotlib.collections import PatchCollection
+    from matplotlib.colors import Normalize
+    from matplotlib.patches import RegularPolygon, Circle, FancyArrowPatch
+    from matplotlib import cm
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+except ImportError:  # pragma: no cover - handled at runtime
+    from lgca.base import _MissingPlotLib  # reuse stub
+
+    animation = colors = mticker = PatchCollection = Normalize = (
+        RegularPolygon
+    ) = Circle = FancyArrowPatch = cm = make_axes_locatable = _MissingPlotLib(
+        "matplotlib"
+    )
 import warnings
 from copy import copy
 

--- a/lgca/plots.py
+++ b/lgca/plots.py
@@ -8,11 +8,18 @@
 import numpy as np
 import random
 from itertools import cycle
-import matplotlib.colors as mplcolors
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
-import matplotlib.cm as cm
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+try:  # optional plotting dependencies
+    import matplotlib.colors as mplcolors
+    import matplotlib.pyplot as plt
+    import matplotlib.ticker as ticker
+    import matplotlib.cm as cm
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+except ImportError:  # pragma: no cover - handled at runtime
+    from lgca.base import _MissingPlotLib
+
+    mplcolors = plt = ticker = cm = make_axes_locatable = _MissingPlotLib(
+        "matplotlib"
+    )
 
 
 class IdentityColourMapper:

--- a/plotting-requirements.txt
+++ b/plotting-requirements.txt
@@ -1,0 +1,2 @@
+matplotlib
+mayavi

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-matplotlib
 numpy
 scipy
 sympy
-mayavi
 tqdm
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,13 @@ project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
+import importlib.util
+import pytest
+
+HAS_MAYAVI = importlib.util.find_spec("mayavi") is not None
+
+
+def pytest_runtest_setup(item):
+    if not HAS_MAYAVI and "cubic" in item.name:
+        pytest.skip("mayavi not installed", allow_module_level=False)
+

--- a/tests/identity_colour_mapper_test.py
+++ b/tests/identity_colour_mapper_test.py
@@ -1,4 +1,7 @@
 import pytest
+
+pytest.importorskip("matplotlib", reason="requires matplotlib for plotting tests")
+
 from lgca.plots import IdentityColourMapper
 
 

--- a/tests/test_get_lgca.py
+++ b/tests/test_get_lgca.py
@@ -6,6 +6,10 @@ from lgca.lgca_square import LGCA_Square, IBLGCA_Square, NoVE_LGCA_Square, NoVE_
 from lgca.lgca_hex import LGCA_Hex, IBLGCA_Hex, NoVE_LGCA_Hex, NoVE_IBLGCA_Hex
 
 try:
+    import mayavi  # noqa: F401
+except Exception:
+    HAS_CUBIC = False
+else:
     from lgca.lgca_cubic import (
         LGCA_Cubic,
         IBLGCA_Cubic,
@@ -13,8 +17,6 @@ try:
         NoVE_IBLGCA_Cubic,
     )
     HAS_CUBIC = True
-except Exception:
-    HAS_CUBIC = False
 
 EXPECTED = {
     'lin': {


### PR DESCRIPTION
## Summary
- move matplotlib and mayavi to optional `plotting-requirements.txt`
- wrap plotting imports with fallbacks
- document optional plotting installation
- skip plotting tests when matplotlib is missing and cubic tests when mayavi is absent

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684568b249548333a98d45aafa6a15e7