### PR TITLE
[Fix] validate node channel count

### DIFF
--- a/lgca/lgca_1d.py
+++ b/lgca/lgca_1d.py
@@ -16,8 +16,12 @@ Supported LGCA types:
 - identity-based LGCA without volume exclusion (:py:class:`NoVE_IBLGCA_1D`)
 """
 
-import matplotlib.ticker as mticker
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+try:  # optional plotting dependency
+    import matplotlib.ticker as mticker
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
+except ImportError:  # pragma: no cover - handled at runtime
+    from lgca.base import _MissingPlotLib
+    mticker = make_axes_locatable = _MissingPlotLib("matplotlib")
 
 from lgca.base import *
 
@@ -73,6 +77,11 @@ class LGCA_1D(LGCA_base):
         # set dimensions according to provided initial condition
         if nodes is not None:
             self.l, self.K = nodes.shape
+            if self.K < self.velocitychannels:
+                raise RuntimeError(
+                    'Not enough channels specified for the chosen geometry! '
+                    f'Required: {self.velocitychannels}, provided: {self.K}'
+                )
             self.restchannels = self.K - self.velocitychannels
             self.dims = self.l,
             return

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -58,6 +58,11 @@ class LGCA_Cubic(LGCA_base):
         """
         if nodes is not None:
             self.lx, self.ly, self.lz, self.K = nodes.shape
+            if self.K < self.velocitychannels:
+                raise RuntimeError(
+                    'Not enough channels specified for the chosen geometry! '
+                    f'Required: {self.velocitychannels}, provided: {self.K}'
+                )
             self.restchannels = self.K - self.velocitychannels
             self.dims = (self.lx, self.ly, self.lz)
             return

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -104,6 +104,11 @@ class LGCA_Square(LGCA_base):
         # set dimensions according to provided initial condition
         if nodes is not None:
             self.lx, self.ly, self.K = nodes.shape
+            if self.K < self.velocitychannels:
+                raise RuntimeError(
+                    'Not enough channels specified for the chosen geometry! '
+                    f'Required: {self.velocitychannels}, provided: {self.K}'
+                )
             self.restchannels = self.K - self.velocitychannels
             self.dims = self.lx, self.ly
             return

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -206,6 +206,16 @@ class Test_LGCA_General:
                 for propname in lgca.props.keys():
                     assert len(lgca.props[propname]) == lgca.maxlabel + 1, "Properties not set up for all particles"
 
+    @pytest.mark.parametrize("geom,nodes", [
+        ('lin', np.zeros((com.xdim_1d, com.b_1d - 1), dtype=bool)),
+        ('square', np.zeros((com.xdim_square, com.ydim_square, com.b_square - 1), dtype=bool)),
+        ('hex', np.zeros((com.xdim_hex, com.ydim_hex, com.b_hex - 1), dtype=bool)),
+        ('cubic', np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic - 1), dtype=bool)),
+    ])
+    def test_nodes_too_few_channels(self, geom, nodes):
+        with pytest.raises(RuntimeError):
+            get_lgca(geometry=geom, nodes=nodes, interaction='only_propagation')
+
     # parameter tuples for 'hom', 'density' keyword check
     # init_particles = number of particles expected in each node int(density*capacity)
     @pytest.mark.parametrize("geom,ve,dims,restchannels,density,init_particles", [


### PR DESCRIPTION
## Summary
- check channel count when initializing LGCA from nodes
- guard optional matplotlib import in 1D implementation
- test providing too few channels

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457102ce9c83339be10d323af5bac6