### PR TITLE
[Fix] use FuncFormatter for density ticks

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -38,8 +38,9 @@ try:  # optional plotting dependencies
     import matplotlib.colors as colors
     from matplotlib import cm, pyplot as plt
     from matplotlib.cm import ScalarMappable
+    from matplotlib.ticker import MaxNLocator, FuncFormatter
 except ImportError:  # pragma: no cover - handled at runtime
-    colors = cm = plt = ScalarMappable = _MissingPlotLib("matplotlib")
+    colors = cm = plt = ScalarMappable = MaxNLocator = FuncFormatter = _MissingPlotLib("matplotlib")
 from numpy import random as npr
 from sympy.utilities.iterables import multiset_permutations
 from tqdm.auto import tqdm
@@ -57,9 +58,9 @@ def colorbar_index(ncolors: int, cmap, use_gridspec: bool=False, cax=None):
 
     Builds a discrete colormap with `ncolors` colors from the near-continuous colormap `cmap`,
     adds it to the axis `cax` and draws tick labels in the center of each color. If
-    ncolors is high, some labels are omitted to avoid cluttering.
-
-    .. note:: To Do: Implement the label stride with Locator and Formatter instead.
+    ncolors is high, tick positions are determined automatically using
+    :class:`~matplotlib.ticker.MaxNLocator` and labels are formatted with
+    :class:`~matplotlib.ticker.FuncFormatter`.
 
     Parameters
     ----------
@@ -80,37 +81,24 @@ def colorbar_index(ncolors: int, cmap, use_gridspec: bool=False, cax=None):
     """
     # discretize the colormap
     cmap = cmap_discretize(cmap, ncolors)
-    # stride the colorbar labels to avoid cluttering for many colors
-    if ncolors > 101:
-        stride = 10
-    elif ncolors > 51:
-        stride = 5
-    elif ncolors > 31:
-        stride = 2
-    else:
-        stride = 1
+
     # map colors to values
     mappable = ScalarMappable(cmap=cmap)
     mappable.set_array([])
-    mappable.set_clim(-0.5, ncolors + 0.5)
-    # create colorbar
-    colorbar = plt.colorbar(mappable, use_gridspec=use_gridspec, cax=cax)
-    # set ticklabels to the center of respective color and support label stride
-    ticks = np.linspace(-0.5, ncolors + 0.5, 2 * ncolors + 1)[1::2]
-    labels = list(range(ncolors))
-    # if last strided label is the maximum label, plot all strided labels
-    if ticks[-1] == ticks[0::stride][-1]:
-        colorbar.set_ticks(ticks[0::stride])
-        colorbar.set_ticklabels(labels[0::stride])
-    # if last strided label is different from the maximum label by less than half the stride:
-    # only plot strided labels up to the second last and the maximum label
-    elif stride > 1 and ticks[-1] != ticks[0::stride][-1] and ticks[-1] - ticks[0::stride][-1] < stride/2:
-        colorbar.set_ticks(list(ticks[0::stride][:-1]) + [ticks[-1]])
-        colorbar.set_ticklabels(labels[0::stride][:-1] + [labels[-1]])
-    # otherwise plot all strided labels and the maximum label
-    else:
-        colorbar.set_ticks(list(ticks[0::stride]) + [ticks[-1]])
-        colorbar.set_ticklabels(labels[0::stride] + [labels[-1]])
+    mappable.set_clim(-0.5, ncolors - 0.5)
+
+    # create colorbar with discrete boundaries
+    boundaries = np.arange(-0.5, ncolors, 1)
+    colorbar = plt.colorbar(
+        mappable, use_gridspec=use_gridspec, cax=cax, boundaries=boundaries
+    )
+
+    # configure ticks and labels using locators and formatters
+    locator = MaxNLocator(nbins="auto", integer=True)
+    formatter = FuncFormatter(lambda val, pos: int(val))
+    colorbar.ax.yaxis.set_major_locator(locator)
+    colorbar.ax.yaxis.set_major_formatter(formatter)
+    colorbar.update_ticks()
     return colorbar
 
 

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -22,6 +22,7 @@ try:  # optional plotting dependencies
     import matplotlib.animation as animation
     import matplotlib.colors as colors
     import matplotlib.ticker as mticker
+    from matplotlib.ticker import FuncFormatter
     from matplotlib.collections import PatchCollection
     from matplotlib.colors import Normalize
     from matplotlib.patches import RegularPolygon, Circle, FancyArrowPatch
@@ -30,7 +31,7 @@ try:  # optional plotting dependencies
 except ImportError:  # pragma: no cover - handled at runtime
     from lgca.base import _MissingPlotLib  # reuse stub
 
-    animation = colors = mticker = PatchCollection = Normalize = (
+    animation = colors = mticker = FuncFormatter = PatchCollection = Normalize = (
         RegularPolygon
     ) = Circle = FancyArrowPatch = cm = make_axes_locatable = _MissingPlotLib(
         "matplotlib"
@@ -653,8 +654,10 @@ class LGCA_Square(LGCA_base):
         else:
             minstep = 1
             integer = False
-        ax.yaxis.set_major_locator(mticker.MaxNLocator(nbins=9, steps=[minstep, 2*self.dy, 5*self.dy, 10*self.dy], integer=integer))
-        ax.yaxis.set_major_formatter(lambda x, pos: (int(x/self.dy)))
+        ax.yaxis.set_major_locator(
+            mticker.MaxNLocator(nbins=9, steps=[minstep, 2 * self.dy, 5 * self.dy, 10 * self.dy], integer=integer)
+        )
+        ax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: int(x / self.dy)))
         ax.spines['top'].set_visible(True)
         ax.spines['right'].set_visible(True)
         ax.yaxis.set_ticks_position('both')
@@ -853,8 +856,8 @@ class LGCA_Square(LGCA_base):
             mappable.set_array(np.arange(K))
             cbar = fig.colorbar(mappable, extend='min', use_gridspec=True, cax=cax)
             cbar.set_label('Particle number $n$')
-            cbar.set_ticks(np.linspace(0., K + 1, 2 * K + 3, endpoint=True)[3::2])
-            cax.yaxis.set_major_formatter(lambda x, pos: (int(x - 0.5)))
+            cbar.set_ticks(np.linspace(0.0, K + 1, 2 * K + 3, endpoint=True)[3::2])
+            cax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: int(x - 0.5)))
             # cbar.set_ticklabels(1 + np.arange(K)) # np.arange(K+1)
             plt.sca(ax)
         else:
@@ -1029,8 +1032,8 @@ class LGCA_Square(LGCA_base):
             cax = divider.append_axes("right", size="5%", pad=0.1)
             cbar = fig.colorbar(cmap, extend='min', use_gridspec=True, cax=cax)
             cbar.set_label(cbarlabel)
-            cbar.set_ticks(np.linspace(0., K + 1, 2 * K + 3, endpoint=True)[3::2])
-            cax.yaxis.set_major_formatter(lambda x, pos: (int(x - 0.5)))
+            cbar.set_ticks(np.linspace(0.0, K + 1, 2 * K + 3, endpoint=True)[3::2])
+            cax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: int(x - 0.5)))
             #cbar.set_ticklabels(1 + np.arange(K)) # np.arange(K+1)
             plt.sca(ax)
 

--- a/lgca/plots.py
+++ b/lgca/plots.py
@@ -12,12 +12,13 @@ try:  # optional plotting dependencies
     import matplotlib.colors as mplcolors
     import matplotlib.pyplot as plt
     import matplotlib.ticker as ticker
+    from matplotlib.ticker import FuncFormatter
     import matplotlib.cm as cm
     from mpl_toolkits.axes_grid1 import make_axes_locatable
 except ImportError:  # pragma: no cover - handled at runtime
     from lgca.base import _MissingPlotLib
 
-    mplcolors = plt = ticker = cm = make_axes_locatable = _MissingPlotLib(
+    mplcolors = plt = ticker = FuncFormatter = cm = make_axes_locatable = _MissingPlotLib(
         "matplotlib"
     )
 
@@ -457,7 +458,7 @@ def muller_plot(root_ID, cum_pop_t, children_nlist, parent_list, timeline, facec
     ax.yaxis.set_minor_locator(ticker.MultipleLocator(0.1))
     ax.xaxis.set_major_locator(ticker.MaxNLocator(integer=True))
     # shift tick labels to start from 0 and stop at 1
-    ax.yaxis.set_major_formatter(lambda x, pos: x + 0.5)
+    ax.yaxis.set_major_formatter(FuncFormatter(lambda x, pos: x + 0.5))
 
     if legend:
         # set up legend, with sorted entries if desired


### PR DESCRIPTION
## Summary
- improve optional imports for ticker formatters
- simplify colorbar tick logic with MaxNLocator and FuncFormatter
- replace `lambda` tick formatters with `FuncFormatter`

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684578a702688333bb387031a1c41a76