### PR TITLE
Feat add repr and str for LGCA classes

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -880,15 +880,20 @@ class LGCA_base(ABC):
         """
         if bc in ['absorbing', 'absorb', 'abs', 'abc', 'fixed']:
             self.apply_boundaries = self.apply_abc
+            self.bc = 'absorbing'
         elif bc in ['reflecting', 'reflect', 'refl', 'rbc', 'no_flux', 'noflux']:
             self.apply_boundaries = self.apply_rbc
+            self.bc = 'reflecting'
         elif bc in ['periodic', 'pbc']:
             self.apply_boundaries = self.apply_pbc
+            self.bc = 'periodic'
         elif bc in ['inflow']:
             self.apply_boundaries = self.apply_inflowbc
+            self.bc = 'inflow'
         else:
             print(bc, 'not defined, using periodic boundaries')
             self.apply_boundaries = self.apply_pbc
+            self.bc = 'periodic'
 
     def calc_flux(self, nodes):
         """
@@ -1107,6 +1112,38 @@ class LGCA_base(ABC):
             Total population size.
         """
         return int(self.cell_density[self.nonborder].sum())
+
+    def __repr__(self) -> str:
+        """Return a concise representation for debugging."""
+        geom = getattr(self, "geometry", "unknown")
+        bc = getattr(self, "bc", "periodic")
+        interaction = getattr(self.interaction, "__name__", str(self.interaction))
+        return (
+            f"{self.__class__.__name__}(geometry={geom}, dims={self.dims}, "
+            f"rest={self.restchannels}, K={self.K}, r_int={self.r_int}, bc={bc}, "
+            f"interaction={interaction})"
+        )
+
+    def __str__(self) -> str:
+        """Human readable summary of the LGCA."""
+        geom = getattr(self, "geometry", "unknown")
+        bc = getattr(self, "bc", "periodic")
+        interaction = getattr(self.interaction, "__name__", str(self.interaction))
+        capacity = getattr(self, "capacity", self.K)
+        prop = "ensemble" if getattr(self, "ensemble", False) else "normal"
+        lines = [
+            f"Model: {self.__class__.__name__}",
+            f"Geometry: {geom}",
+            f"Dimensions: {self.dims}",
+            f"Rest channels: {self.restchannels}",
+            f"Carrying capacity: {capacity}",
+            f"Interaction radius: {self.r_int}",
+            f"Boundary conditions: {bc}",
+            f"Propagation: {prop}",
+            f"Interaction: {interaction}",
+            f"Interaction parameters: {self.interaction_params}",
+        ]
+        return "\n".join(lines)
 
 
 class IBLGCA_base(LGCA_base, ABC):

--- a/lgca/lgca_1d.py
+++ b/lgca/lgca_1d.py
@@ -46,6 +46,7 @@ class LGCA_1D(LGCA_base):
 
     """
     # set class attributes
+    geometry = 'lin'
     interactions = ['go_and_grow', 'go_or_grow', 'alignment', 'aggregation', 'parameter_controlled_diffusion',
                     'random_walk', 'persistent_motion', 'birthdeath', 'only_propagation']
     velocitychannels = 2

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -26,6 +26,7 @@ class LGCA_Cubic(LGCA_base):
     """
 
     # Set class attributes
+    geometry = 'cubic'
     interactions = [
         "go_and_grow",
         "go_or_grow",

--- a/lgca/lgca_hex.py
+++ b/lgca/lgca_hex.py
@@ -55,6 +55,7 @@ class LGCA_Hex(LGCA_Square):
 
     """
     # set class attributes
+    geometry = 'hex'
     # interactions are inherited from 2D square LGCA
     velocitychannels = 6
     cix = np.cos(np.arange(velocitychannels) * pi2 / velocitychannels)

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -71,6 +71,7 @@ class LGCA_Square(LGCA_base):
 
     """
     # set class attributes
+    geometry = 'square'
     interactions = ['go_and_grow', 'go_or_grow', 'alignment', 'aggregation',
                     'random_walk', 'excitable_medium', 'nematic', 'persistent_motion', 'chemotaxis', 'contact_guidance',
                     'only_propagation']

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -1,0 +1,28 @@
+import pytest
+from lgca import get_lgca
+
+try:
+    from lgca.lgca_cubic import LGCA_Cubic  # noqa: F401
+except Exception:
+    HAS_CUBIC = False
+else:
+    HAS_CUBIC = True
+
+geometries = ['lin', 'square', 'hex']
+if HAS_CUBIC:
+    geometries.append('cubic')
+
+@pytest.mark.parametrize('geom', geometries)
+def test_repr_and_str(geom):
+    lgca = get_lgca(geometry=geom, dims=2, interaction='only_propagation')
+    r = repr(lgca)
+    assert lgca.__class__.__name__ in r
+    assert f"geometry={lgca.geometry}" in r
+    assert f"dims={lgca.dims}" in r
+    assert "bc=periodic" in r
+    assert "interaction=only_propagation" in r
+
+    s = str(lgca)
+    assert "Model:" in s
+    assert f"Geometry: {lgca.geometry}" in s
+    assert "Interaction:" in s


### PR DESCRIPTION
## Summary
- implement __repr__ and __str__ in LGCA_base
- store boundary condition name
- add geometry attribute for each geometry class
- test new representations

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68458537d3988333af6d424f65290a10