### PR TITLE
[Fix] remove homogeneous random reset

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -937,48 +937,8 @@ class LGCA_base(ABC):
             Desired average particle density of the lattice.
             ``density = total_number_of_particles / (number_of_nodes * number_of_channels_per_node)``.
 
-        See Also
-        --------
-        homogeneous_random_reset : Initialize the lattice randomly with a fixed number of particles per node.
-
         """
         self.nodes = npr.random(self.nodes.shape) < density
-        self.apply_boundaries()
-        self.update_dynamic_fields()
-
-    def homogeneous_random_reset(self, density):
-        """
-        Initialize lattice nodes with average density `density`. Channels are occupied at random and all nodes
-        have the same particle number.
-
-        The particle number per node that matches `density` most closely is determined. The configuration for one
-        node with this number of particles is then permutated to fill the lattice.
-
-
-        Parameters
-        ----------
-        density : float
-            Desired average density of the lattice.
-            ``density = total_number_of_particles / (number_of_nodes * number_of_channels_per_node)``.
-            Here also: ``density = number_of_particles_per_node / number_of_channels_per_node``.
-
-        See Also
-        --------
-        random_reset : Initialize the lattice randomly with a varying number of particles per node.
-
-        """
-        # find the number of particles per lattice site which is closest to the desired density
-        if int(density * self.K) == density * self.K:
-            initcells = int(density * self.K)
-        else:
-            initcells = min(int(density * self.K) + 1, self.K)
-        # create a configuration for one node with the calculated number of particles
-        channels = [1] * initcells + [0] * (self.K - initcells)
-        # permutate it to fill the lattice
-        n_nodes = self.nodes[..., 0].size
-        channels = np.array([npr.permutation(channels) for _ in range(n_nodes)])
-        self.nodes = channels.reshape(self.nodes.shape)
-
         self.apply_boundaries()
         self.update_dynamic_fields()
         # achieved density
@@ -2418,7 +2378,7 @@ class NoVE_LGCA_base(LGCA_base, ABC):
     """
     Base class for LGCA without volume exclusion.
     """
-    def __init__(self, nodes=None, dims=None, restchannels=1, density=0.1, hom=None, bc='periodic', seed=None, capacity=None,
+    def __init__(self, nodes=None, dims=None, restchannels=1, density=0.1, bc='periodic', seed=None, capacity=None,
                  **kwargs):
         """
         Initialize class instance.
@@ -2435,7 +2395,7 @@ class NoVE_LGCA_base(LGCA_base, ABC):
         self.set_bc(bc)
         self.set_dims(dims=dims, restchannels=restchannels, nodes=nodes, capacity=capacity)
         self.init_coords()
-        self.init_nodes(density=density, nodes=nodes, hom=hom)
+        self.init_nodes(density=density, nodes=nodes)
         self.update_dynamic_fields()
         self.interaction_params = {}
         self.set_interaction(**kwargs)
@@ -2628,24 +2588,6 @@ class NoVE_LGCA_base(LGCA_base, ABC):
         eff_dens = self.nodes[self.nonborder].sum()/(self.capacity * self.cell_density[self.nonborder].size)
         print("Required density: {:.3f}, Achieved density: {:.3f}".format(density, eff_dens))
 
-    def homogeneous_random_reset(self, density):
-        """
-        Distribute particles in the lattice homogeneously according to a given density: each lattice site has the same
-            number of particles, randomly distributed among the channels
-        :param density: particle density in the lattice: number of particles/(dimensions*capacity)
-        """
-        # find the number of particles per lattice site which is closest to the desired density
-        if int(density * self.capacity) == density * self.capacity:
-            initcells = int(density * self.capacity)
-        else:
-            initcells = int(density * self.capacity) + 1
-        # distribute calculated number of particles among channels in the lattice
-        self.nodes = npr.multinomial(initcells, [1 / self.K] * self.K, size=self.nodes.shape[:-1])
-        self.apply_boundaries()
-        self.update_dynamic_fields()
-        # check result
-        eff_dens = self.nodes[self.nonborder].sum() / (self.capacity * self.cell_density[self.nonborder].size)
-        print("Required density: {:.3f}, Achieved density: {:.3f}".format(density, eff_dens))
 
     def calc_entropy(self, base=None):
         """

--- a/lgca/lgca_1d.py
+++ b/lgca/lgca_1d.py
@@ -114,17 +114,12 @@ class LGCA_1D(LGCA_base):
         ----------
         density : float, default=0.1
             If `nodes` is None, initialize lattice randomly with this particle density.
-        hom : float, default=False
-            Fill channels randomly with particle density `density`, but with an equal number of particles for each node.
-            Note that depending on :py:attr:`self.K` not all densities can be realized.
         nodes : :py:class:`numpy.ndarray`
             Custom initial lattice configuration. Dimensions: ``(self.dims[0], self.K)``.
 
         See Also
         --------
         base.LGCA_base.random_reset : Initialize lattice nodes with average density `density`.
-        base.LGCA_base.homogeneous_random_reset : Initialize lattice nodes with average density `density` and a fixed number
-            of particles per node.
         set_dims : Set LGCA dimensions.
         init_coords : Initialize LGCA coordinates.
 
@@ -132,13 +127,7 @@ class LGCA_1D(LGCA_base):
         self.nodes = np.zeros((self.l + 2 * self.r_int, self.K), dtype=bool)
 
         # random initialization
-        if 'hom' in kwargs:
-            hom = kwargs['hom']
-        else:
-            hom = None
-        if nodes is None and hom:
-            self.homogeneous_random_reset(density)
-        elif nodes is None:
+        if nodes is None:
             self.random_reset(density)
         # initialization with provided initial condition
         else:
@@ -666,7 +655,7 @@ class NoVE_LGCA_1D(LGCA_1D, NoVE_LGCA_base):
         else:
             self.capacity = self.K
 
-    def init_nodes(self, density, nodes=None, hom=None):
+    def init_nodes(self, density, nodes=None):
         """
         Initialize nodes for the instance.
         :param density: desired particle density in the lattice: number of particles/(dimensions*number of channels)
@@ -676,10 +665,7 @@ class NoVE_LGCA_1D(LGCA_1D, NoVE_LGCA_base):
         self.nodes = np.zeros((self.l + 2 * self.r_int, self.K), dtype=np.uint)
         # if no lattice given, populate randomly
         if nodes is None:
-            if hom:
-                self.homogeneous_random_reset(density)
-            else:
-                self.random_reset(density)
+            self.random_reset(density)
         # if lattice given, populate lattice with given particles. Virtual lattice sites for boundary conditions not included
         else:
             self._warn_nodes_shape(nodes)

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -98,7 +98,7 @@ class LGCA_Cubic(LGCA_base):
         self.K = self.velocitychannels + self.restchannels
         self.capacity = capacity if capacity is not None else self.K
 
-    def init_nodes(self, density=0.1, nodes=None, hom=None, **kwargs):
+    def init_nodes(self, density=0.1, nodes=None, **kwargs):
         """
         Initialize LGCA lattice configuration. Create the lattice and then assign particles to channels in the nodes.
 
@@ -129,10 +129,7 @@ class LGCA_Cubic(LGCA_base):
         )
 
         if nodes is None:
-            if hom:
-                self.homogeneous_random_reset(density)
-            else:
-                self.random_reset(density)
+            self.random_reset(density)
         else:
             self._warn_nodes_shape(nodes)
             self.nodes[self.nonborder] = nodes.astype(bool)
@@ -1130,7 +1127,7 @@ class NoVE_LGCA_Cubic(LGCA_Cubic, NoVE_LGCA_base):
         self.K = self.velocitychannels + self.restchannels
         self.capacity = capacity if capacity is not None else self.K
 
-    def init_nodes(self, density=4, nodes=None, hom=False):
+    def init_nodes(self, density=4, nodes=None):
         """
         Initialize lattice nodes.
         """
@@ -1144,10 +1141,7 @@ class NoVE_LGCA_Cubic(LGCA_Cubic, NoVE_LGCA_base):
             dtype=np.uint,
         )
         if nodes is None:
-            if hom:
-                self.homogeneous_random_reset(density)
-            else:
-                self.random_reset(density)
+            self.random_reset(density)
         else:
             self._warn_nodes_shape(nodes)
             self.nodes[

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -145,30 +145,19 @@ class LGCA_Square(LGCA_base):
         ----------
         density : float, default=0.1
             If `nodes` is None, initialize lattice randomly with this particle density.
-        hom : float, default=False
-            Fill channels randomly with particle density `density`, but with an equal number of particles for each node.
-            Note that depending on :py:attr:`self.K` not all densities can be realized.
         nodes : :py:class:`numpy.ndarray`
             Custom initial lattice configuration. Dimensions: ``(self.dims[0], self.dims[1], self.K)``.
 
         See Also
         --------
         base.LGCA_base.random_reset : Initialize lattice nodes with average density `density`.
-        base.LGCA_base.homogeneous_random_reset : Initialize lattice nodes with average density `density` and a fixed number
-            of particles per node.
         set_dims : Set LGCA dimensions.
         init_coords : Initialize LGCA coordinates.
 
         """
         self.nodes = np.zeros((self.lx + 2 * self.r_int, self.ly + 2 * self.r_int, self.K), dtype=bool)
         # random initialization
-        if 'hom' in kwargs:
-            hom = kwargs['hom']
-        else:
-            hom = None
-        if nodes is None and hom:
-            self.homogeneous_random_reset(density)
-        elif nodes is None:
+        if nodes is None:
             self.random_reset(density)
         # initialization with provided initial condition
         else:
@@ -1338,13 +1327,10 @@ class NoVE_LGCA_Square(LGCA_Square, NoVE_LGCA_base):
         else:
             self.capacity = self.K
 
-    def init_nodes(self, density=4, nodes=None, hom=None):
+    def init_nodes(self, density=4, nodes=None):
         self.nodes = np.zeros((self.lx + 2 * self.r_int, self.ly + 2 * self.r_int, self.K), dtype=np.uint)
         if nodes is None:
-            if hom:
-                self.homogeneous_random_reset(density)
-            else:
-                self.random_reset(density)
+            self.random_reset(density)
         else:
             self._warn_nodes_shape(nodes)
             self.nodes[self.r_int:-self.r_int, self.r_int:-self.r_int, :] = nodes.astype(np.uint)

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -182,9 +182,17 @@ class Test_LGCA_General:
     ])
     def test_getlgca_lattice_setup_nodes(self, geom, ve, ib, nodes, dims, restchannels):
         # 'node' keyword check: provided lattice is adopted by LGCA
-        # if nodes are provided, 'restchannels', 'dims', 'density' and 'hom' have to be ignored
-        lgca = get_lgca(geometry=geom, ve=ve, ib=ib, nodes=nodes, dims=dims, density=0.01, restchannels=restchannels+1,
-                        hom=True, interaction='only_propagation')
+        # if nodes are provided, 'restchannels', 'dims' and 'density' have to be ignored
+        lgca = get_lgca(
+            geometry=geom,
+            ve=ve,
+            ib=ib,
+            nodes=nodes,
+            dims=dims,
+            density=0.01,
+            restchannels=restchannels + 1,
+            interaction='only_propagation'
+        )
         assert np.array_equal(lgca.nodes[lgca.nonborder], nodes), "Nodes not adopted correctly"
         assert lgca.restchannels == restchannels, "Wrong number of rest channels defined if nodes are given"
         assert lgca.dims == nodes.shape[:-1], "Wrong dimensions defined if nodes are given"
@@ -215,47 +223,6 @@ class Test_LGCA_General:
     def test_nodes_too_few_channels(self, geom, nodes):
         with pytest.raises(RuntimeError):
             get_lgca(geometry=geom, nodes=nodes, interaction='only_propagation')
-
-    # parameter tuples for 'hom', 'density' keyword check
-    # init_particles = number of particles expected in each node int(density*capacity)
-    @pytest.mark.parametrize("geom,ve,dims,restchannels,density,init_particles", [
-        # classical LGCA (ve, non-ib)
-        # (geom,    ve,   dims,                               restchannels,                  density,    init_particles)
-        ('lin',     True, (com.xdim_1d,),                     com.restchannels_ve_1d,        density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_1d, K=com.K_ve_1d)),
-        ('square',  True, (com.xdim_square, com.ydim_square), com.restchannels_ve_square,    density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_square, K=com.K_ve_square)),
-        ('hex',     True, (com.xdim_hex, com.ydim_hex),       com.restchannels_ve_hex,       density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_hex, K=com.K_ve_hex)),
-        ('cubic',   True, (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_ve_cubic, density_ve, calc_init_particles(True, density_ve, com.restchannels_ve_cubic, K=com.K_ve_cubic)),
-        # NoVE_LGCA (nove, non-ib)
-        # written assuming that capacity for nove is set to velocitychannels + restchannels
-        # (geom,    ve,    dims,                               restchannels,                 density,        init_particles)
-        ('lin',     False, (com.xdim_1d,),                     com.restchannels_nove_1d,     density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_1d, b=com.b_1d)),
-        ('square',  False, (com.xdim_square, com.ydim_square), com.restchannels_nove_square, density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_square, b=com.b_square)),
-        ('hex',     False, (com.xdim_hex, com.ydim_hex),       com.restchannels_nove_hex,    density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_hex, b=com.b_hex)),
-        ('cubic',   False, (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_nove_cubic, density_nove_1, calc_init_particles(False, density_nove_1, com.restchannels_nove_cubic, b=com.b_cubic)),
-        # (geom,    ve,    dims,                               restchannels,                 density,        init_particles)
-        ('lin',     False, (com.xdim_1d,),                     com.restchannels_nove_1d,     density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_1d, b=com.b_1d)),
-        ('square',  False, (com.xdim_square, com.ydim_square), com.restchannels_nove_square, density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_square, b=com.b_square)),
-        ('hex',     False, (com.xdim_hex, com.ydim_hex),       com.restchannels_nove_hex,    density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_hex, b=com.b_hex))
-        ,('cubic',   False, (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_nove_cubic,    density_nove_2, calc_init_particles(False, density_nove_2, com.restchannels_nove_cubic, b=com.b_cubic))
-    ])
-    def test_getlgca_lattice_setup_homogeneous(self, geom, ve, dims, restchannels, density, init_particles):
-        # 'hom', 'density' keyword check
-        lgca = get_lgca(geometry=geom, ve=ve, ib=False, dims=dims, density=density, hom=True, restchannels=restchannels,
-                        interaction='only_propagation')
-        assert lgca.dims == dims, "Wrong dimensions defined"
-        # in the excluded case the lattice will be fully filled
-        if not (ve and density == 1):
-            # compare flattened node config to config moved one node forward to see if nodes all have the same config
-            assert not np.array_equal(lgca.nodes[lgca.nonborder].flatten(),
-                                      np.roll(lgca.nodes[lgca.nonborder].flatten(), lgca.nodes.shape[-1])), \
-                "Node configuration is not random"
-        if geom == 'cubic' and ve:
-            pytest.xfail("Homogeneous initialization unstable for cubic geometry")
-        assert np.all(lgca.nodes[lgca.nonborder].sum(-1) == init_particles), \
-            "Density not reached or not reached homogeneously"
-        if ve:
-            assert np.max(lgca.nodes.astype(int)) <= 1, "Volume exclusion principle is not respected"
-
     # parameter tuples for 'density' keyword check, random reset
     @pytest.mark.parametrize("geom,ve,ib,dims_large,restchannels,density,capacity", [
         # classical LGCA (ve, non-ib)

--- a/tests/nove_ib_test.py
+++ b/tests/nove_ib_test.py
@@ -369,13 +369,13 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
         assert lgca.capacity == capacity
         lgca = get_lgca(geometry=geom, ve=False, ib=True, density=density, capacity=capacity, interaction="only_propagation")
         assert lgca.capacity == capacity
-        lgca = get_lgca(geometry=geom, ve=False, ib=True, density=density, hom=True, capacity=capacity, interaction="only_propagation")
+        lgca = get_lgca(geometry=geom, ve=False, ib=True, density=density, capacity=capacity, interaction="only_propagation")
         assert lgca.capacity == capacity
         lgca = get_lgca(geometry=geom, ve=False, ib=True, nodes=nodes_ib, restchannels=1, interaction="only_propagation")
         assert lgca.capacity == b + 1
         lgca = get_lgca(geometry=geom, ve=False, ib=True, density=density, restchannels=1, interaction="only_propagation")
         assert lgca.capacity == b + 1
-        lgca = get_lgca(geometry=geom, ve=False, ib=True, density=density, hom=True, restchannels=1, interaction="only_propagation")
+        lgca = get_lgca(geometry=geom, ve=False, ib=True, density=density, restchannels=1, interaction="only_propagation")
         assert lgca.capacity == b + 1
 
     @pytest.mark.parametrize("geom,nodes", [

--- a/tests/nove_test.py
+++ b/tests/nove_test.py
@@ -507,17 +507,6 @@ class Test_LGCA_NoVE(T_LGCA_Common):
         lgca = get_lgca(
             geometry=geom,
             ve=False,
-            density=density,
-            hom=True,
-            capacity=capacity,
-            interaction="only_propagation",
-        )
-        assert (
-            lgca.capacity == capacity
-        ), "Capacity keyword not respected in homogeneous random reset"
-        lgca = get_lgca(
-            geometry=geom,
-            ve=False,
             nodes=nodes,
             restchannels=restchannels,
             interaction="only_propagation",
@@ -535,28 +524,6 @@ class Test_LGCA_NoVE(T_LGCA_Common):
         assert (
             lgca.capacity == b + restchannels
         ), "Capacity not correctly calculated from provided geometry and rest channels"
-        lgca = get_lgca(
-            geometry=geom,
-            ve=False,
-            density=density,
-            hom=True,
-            restchannels=restchannels,
-            interaction="only_propagation",
-        )
-        assert (
-            lgca.capacity == b + restchannels
-        ), "Capacity not correctly calculated from provided geometry and rest channels"
-
-    @pytest.mark.parametrize(
-        "geom,nodes",
-        [
-            ("lin", com.nodes_nove_1d),
-            ("square", com.nodes_nove_square),
-            ("hex", com.nodes_nove_hex),
-            ("cubic", com.nodes_nove_cubic),
-        ],
-    )
-
     @pytest.mark.skip(reason="unstable with missing numba")
     def test_characteristics(self, geom, nodes):
         # volume exclusion does not have to be checked here, uniqueness neither


### PR DESCRIPTION
## Summary
- drop homogeneous_random_reset from base classes
- update initialization methods to only use random_reset
- remove obsolete hom parameter from tests and code

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684586861f1883339444a1ae4cb3eeac