### PR TITLE
[Feat] enforce boolean nodes

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -561,6 +561,16 @@ class LGCA_base(ABC):
                 UserWarning,
             )
 
+    def _ensure_bool_nodes(self, nodes):
+        """Return ``nodes`` as boolean array, warn if non-boolean values found."""
+        if not np.isin(nodes, [0, 1]).all():
+            warnings.warn(
+                "Provided nodes contain values other than 0 or 1. "
+                "Interpreting values as booleans.",
+                UserWarning,
+            )
+        return nodes.astype(bool)
+
     def __init__(self, nodes=None, dims=None, restchannels=0, density=0.1,
                  bc='periodic', seed=None, propagation=True, **kwargs):
         """Initialize class instance. See class docstring."""

--- a/lgca/lgca_1d.py
+++ b/lgca/lgca_1d.py
@@ -133,7 +133,7 @@ class LGCA_1D(LGCA_base):
         # initialization with provided initial condition
         else:
             self._warn_nodes_shape(nodes)
-            self.nodes[self.r_int:-self.r_int, :] = nodes.astype(bool)
+            self.nodes[self.r_int:-self.r_int, :] = self._ensure_bool_nodes(nodes)
             self.apply_boundaries()
 
     def init_coords(self):

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -133,7 +133,7 @@ class LGCA_Cubic(LGCA_base):
             self.random_reset(density)
         else:
             self._warn_nodes_shape(nodes)
-            self.nodes[self.nonborder] = nodes.astype(bool)
+            self.nodes[self.nonborder] = self._ensure_bool_nodes(nodes)
             self.apply_boundaries()
 
     def init_coords(self):

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -163,7 +163,7 @@ class LGCA_Square(LGCA_base):
         # initialization with provided initial condition
         else:
             self._warn_nodes_shape(nodes)
-            self.nodes[self.r_int:-self.r_int, self.r_int:-self.r_int, :] = nodes.astype(bool)
+            self.nodes[self.r_int:-self.r_int, self.r_int:-self.r_int, :] = self._ensure_bool_nodes(nodes)
             self.apply_boundaries()
 
     def init_coords(self):

--- a/tests/test_get_lgca.py
+++ b/tests/test_get_lgca.py
@@ -87,3 +87,16 @@ def test_warning_on_mismatched_restchannels():
             interaction='only_propagation',
         )
 
+
+def test_warning_on_nonboolean_nodes():
+    nodes = np.array([[2, 0], [3, 1]])
+    with pytest.warns(UserWarning):
+        lgca = get_lgca(
+            geometry='lin',
+            ib=False,
+            ve=True,
+            nodes=nodes,
+            interaction='only_propagation',
+        )
+    assert set(np.unique(lgca.nodes[lgca.nonborder])) <= {0, 1}
+


### PR DESCRIPTION
## Summary
- warn if non-boolean values are provided for classical LGCA nodes
- convert any non-zero values to boolean
- cover behaviour with a new unit test

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684593047f148333af8aa9db7f86ddd8