### PR TITLE
Docs update 3D cubic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@ currently supported are:
 - classical LGCA without volume exclusion (all particles/cells have the same properties)
 - identity-based LGCA without volume exclusion (particles/cells can have individual properties)
 
-These can be simulated in a 1D, 2D square, 2D hexagonal or 3D cubic lattice. A [library of
-interaction rules](./lgca/interactions.py) (documentation under construction) is already implemented. Adding a custom
-interaction rule or customising other parts of the simulation (e.g. the interaction
-radius) is easy.
+These can be simulated in 1D, 2D square, 2D hexagonal, and **3D cubic** lattices. A
+[library of interaction rules](./lgca/interactions.py) (documentation under construction) is already implemented.
+Adding a custom interaction rule or customising other parts of the simulation (e.g. the interaction radius) is easy.
 
 Current analysis possibilities include plots of:
 - density (+ animation)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,10 +21,9 @@ currently supported are:
 - classical LGCA without volume exclusion (all particles/cells have the same properties)
 - identity-based LGCA without volume exclusion (particles/cells can have individual properties)
 
-These can be simulated in a 1D, 2D square, 2D hexagonal or 3D cubic lattice. A [library of
-interaction rules](./lgca/interactions.py) (documentation under construction) is already implemented. Adding a custom
-interaction rule or customising other parts of the simulation (e.g. the interaction
-radius) is easy.
+These can be simulated in 1D, 2D square, 2D hexagonal, and **3D cubic** lattices. A
+[library of interaction rules](./lgca/interactions.py) (documentation under construction) is already implemented.
+Adding a custom interaction rule or customising other parts of the simulation (e.g. the interaction radius) is easy.
 
 Current analysis possibilities include plots of:
 - density (+ animation)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,7 @@ The types of LGCA currently supported are:
 - classical LGCA without volume exclusion (all particles/cells have the same properties)
 - identity-based LGCA without volume exclusion (particles/cells can have individual properties)
 
-These can be simulated in a 1D, 2D square, 2D hexagonal or 3D cubic lattice.  A
+These can be simulated in 1D, 2D square, 2D hexagonal, and **3D cubic** lattices.  A
 :ref:`library of interaction rules <interaction_chapter>` is already
 implemented.  :ref:`Adding a custom interaction rule <adding_own_interactions>`
 or customising other parts of the simulation (e.g. the interaction radius) is easy.

--- a/lgca/__init__.py
+++ b/lgca/__init__.py
@@ -15,9 +15,9 @@ The get_lgca function returns an LGCA object of the requested type with the
 given initial conditions. It can simulate for a given number of timesteps and has
 different plotting functions for analysis, depending on the geometry. The
 interaction function can be chosen from built-in ones or defined by the user.
-Currently, classical LGCA and identity-based LGCA with and without volume 
-exclusion, respectively, are
-supported on 1D, 2D square and 2D hexagonal lattices.
+Currently, classical LGCA and identity-based LGCA with and without volume
+exclusion, respectively, are supported on 1D, 2D square, 2D hexagonal and
+3D cubic lattices.
 
 References
 ----------
@@ -113,11 +113,11 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
 
     Parameters
     ----------
-    geometry : {'hex', 'square', 'lin'}, default='hex'
-        Lattice geometry. Supported are 1D, 2D square and 2D hexagonal lattices.
+    geometry : {'hex', 'square', 'lin', 'cubic'}, default='hex'
+        Lattice geometry. Supported are 1D, 2D square, 2D hexagonal and 3D cubic lattices.
 
         Aliases: 1D: ``'1D', '1d', 'linear'``; 2D square: ``'sq', 'rect', 'rectangular'``;
-        2D hexagonal: ``'hexagonal', 'hx'``.
+        2D hexagonal: ``'hexagonal', 'hx'``; 3D cubic: ``'cubic', 'cb'``.
     ib : bool, default=False
         If the LGCA should be identity-based (every particle can have individual properties).
     ve : bool, default=True


### PR DESCRIPTION
## Summary
- update README and docs to reference 3D cubic lattice support
- clarify geometry options in `get_lgca` docstring

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845966ee58c8333b002e7014b1fea52