### PR TITLE
[Fix] Add Moore propagation tests for all models

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ currently supported are:
 - classical LGCA without volume exclusion (all particles/cells have the same properties)
 - identity-based LGCA without volume exclusion (particles/cells can have individual properties)
 
-These can be simulated in 1D, 2D square, 2D hexagonal, and **3D cubic** lattices. A
+These can be simulated in 1D, 2D square, 2D hexagonal, **3D cubic**, and **3D Moore** lattices. A
 [library of interaction rules](./lgca/interactions.py) (documentation under construction) is already implemented.
 Adding a custom interaction rule or customising other parts of the simulation (e.g. the interaction radius) is easy.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ currently supported are:
 - classical LGCA without volume exclusion (all particles/cells have the same properties)
 - identity-based LGCA without volume exclusion (particles/cells can have individual properties)
 
-These can be simulated in 1D, 2D square, 2D hexagonal, and **3D cubic** lattices. A
+These can be simulated in 1D, 2D square, 2D hexagonal, **3D cubic**, and **3D Moore** lattices. A
 [library of interaction rules](./lgca/interactions.py) (documentation under construction) is already implemented.
 Adding a custom interaction rule or customising other parts of the simulation (e.g. the interaction radius) is easy.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -48,7 +48,7 @@ The types of LGCA currently supported are:
 - classical LGCA without volume exclusion (all particles/cells have the same properties)
 - identity-based LGCA without volume exclusion (particles/cells can have individual properties)
 
-These can be simulated in 1D, 2D square, 2D hexagonal, and **3D cubic** lattices.  A
+These can be simulated in 1D, 2D square, 2D hexagonal, **3D cubic**, and **3D Moore** lattices.  A
 :ref:`library of interaction rules <interaction_chapter>` is already
 implemented.  :ref:`Adding a custom interaction rule <adding_own_interactions>`
 or customising other parts of the simulation (e.g. the interaction radius) is easy.

--- a/docs/source/lattice_geometries.rst
+++ b/docs/source/lattice_geometries.rst
@@ -34,3 +34,19 @@ has six velocity channels pointing to the neighbouring cubes along the cardinal
 directions.  A resting channel may also be present.  Propagation moves particles
 to adjacent cubes in three dimensions.
 
+3-dimensional Moore lattice
+---------------------------
+
+This lattice extends the cubic neighbourhood to include the 26 surrounding
+nodes in all directions. Each node therefore has 26 velocity channels pointing
+to all combinations of ``(dx, dy, dz)`` in ``{-1, 0, 1}`` except the origin. The
+resulting neighbourhood is often called the *Moore* neighbourhood in three
+dimensions. Propagation moves particles to any of the adjacent or diagonal
+neighbours as well as allowing a rest channel when configured.
+
+Example::
+
+    from lgca import get_lgca
+    lgca = get_lgca(geometry='moore')
+
+

--- a/lgca/__init__.py
+++ b/lgca/__init__.py
@@ -16,8 +16,8 @@ given initial conditions. It can simulate for a given number of timesteps and ha
 different plotting functions for analysis, depending on the geometry. The
 interaction function can be chosen from built-in ones or defined by the user.
 Currently, classical LGCA and identity-based LGCA with and without volume
-exclusion, respectively, are supported on 1D, 2D square, 2D hexagonal and
-3D cubic lattices.
+exclusion, respectively, are supported on 1D, 2D square, 2D hexagonal,
+3D cubic and 3D Moore lattices.
 
 References
 ----------
@@ -53,7 +53,7 @@ def _translate_dims(dims: Any, geom_key: str) -> Tuple[int, ...]:
             return (dims[0],)
         if geom_key in {'square', 'hex'}:
             return (dims[0], dims[1]) if len(dims) > 1 else (dims[0], dims[0])
-        if geom_key == 'cubic':
+        if geom_key in {'cubic', 'moore'}:
             if len(dims) >= 3:
                 return dims[0], dims[1], dims[2]
             if len(dims) == 2:
@@ -65,7 +65,7 @@ def _translate_dims(dims: Any, geom_key: str) -> Tuple[int, ...]:
         if geom_key in {'square', 'hex'}:
             d = int(dims)
             return (d, d)
-        if geom_key == 'cubic':
+        if geom_key in {'cubic', 'moore'}:
             d = int(dims)
             return (d, d, d)
     return tuple(dims)
@@ -81,6 +81,7 @@ def _warn_on_node_mismatch(nodes, dims_arg, rest_arg, geom_key):
         'square': 4,
         'hex': 6,
         'cubic': 6,
+        'moore': 26,
     }
 
     dims_from_nodes = nodes.shape[:-1]
@@ -113,11 +114,13 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
 
     Parameters
     ----------
-    geometry : {'hex', 'square', 'lin', 'cubic'}, default='hex'
-        Lattice geometry. Supported are 1D, 2D square, 2D hexagonal and 3D cubic lattices.
+    geometry : {'hex', 'square', 'lin', 'cubic', 'moore'}, default='hex'
+        Lattice geometry. Supported are 1D, 2D square, 2D hexagonal,
+        3D cubic and 3D Moore lattices.
 
         Aliases: 1D: ``'1D', '1d', 'linear'``; 2D square: ``'sq', 'rect', 'rectangular'``;
-        2D hexagonal: ``'hexagonal', 'hx'``; 3D cubic: ``'cubic', 'cb'``.
+        2D hexagonal: ``'hexagonal', 'hx'``; 3D cubic: ``'cubic', 'cb'``;
+        3D Moore: ``'moore3d'``.
     ib : bool, default=False
         If the LGCA should be identity-based (every particle can have individual properties).
     ve : bool, default=True
@@ -205,6 +208,8 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
         'hexagonal': 'hex',
         'cubic': 'cubic',
         'cb': 'cubic',
+        'moore': 'moore',
+        'moore3d': 'moore',
     }
 
     geom_key = geom_map.get(geometry, geometry)
@@ -218,10 +223,12 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
             from lgca.lgca_hex import NoVE_LGCA_Hex as _Cls
         elif geom_key == 'cubic':
             from lgca.lgca_cubic import NoVE_LGCA_Cubic as _Cls
+        elif geom_key == 'moore':
+            from lgca.lgca_3dmoore import NoVE_LGCA_Moore as _Cls
         else:
             raise ValueError(
                 "Geometry specification is unknown. Try: '1d', 'lin', 'linear', 'square', 'sq', "
-                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', or 'cb'."
+                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', 'cb', or 'moore3d'."
             )
     elif ib and ve:
         if geom_key == 'lin':
@@ -232,10 +239,12 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
             from lgca.lgca_hex import IBLGCA_Hex as _Cls
         elif geom_key == 'cubic':
             from lgca.lgca_cubic import IBLGCA_Cubic as _Cls
+        elif geom_key == 'moore':
+            from lgca.lgca_3dmoore import IBLGCA_Moore as _Cls
         else:
             raise ValueError(
                 "Geometry specification is unknown. Try: '1d', 'lin', 'linear', 'square', 'sq', "
-                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', or 'cb'."
+                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', 'cb', or 'moore3d'."
             )
     elif not ve and ib:
         if geom_key == 'lin':
@@ -246,10 +255,12 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
             from lgca.lgca_hex import NoVE_IBLGCA_Hex as _Cls
         elif geom_key == 'cubic':
             from lgca.lgca_cubic import NoVE_IBLGCA_Cubic as _Cls
+        elif geom_key == 'moore':
+            from lgca.lgca_3dmoore import NoVE_IBLGCA_Moore as _Cls
         else:
             raise ValueError(
                 "Geometry specification is unknown. Try: '1d', 'lin', 'linear', 'square', 'sq', "
-                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', or 'cb'."
+                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', 'cb', or 'moore3d'."
             )
     else:
         if geom_key == 'lin':
@@ -260,10 +271,12 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
             from lgca.lgca_hex import LGCA_Hex as _Cls
         elif geom_key == 'cubic':
             from lgca.lgca_cubic import LGCA_Cubic as _Cls
+        elif geom_key == 'moore':
+            from lgca.lgca_3dmoore import LGCA_3dMoore as _Cls
         else:
             raise ValueError(
                 "Geometry specification is unknown. Try: '1d', 'lin', 'linear', 'square', 'sq', "
-                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', or 'cb'."
+                "'rect', 'rectangular', 'hex', 'hx',  'hexagonal', 'cubic', 'cb', or 'moore3d'."
             )
 
     lgca = _Cls(**kwargs)

--- a/lgca/lgca_3dmoore.py
+++ b/lgca/lgca_3dmoore.py
@@ -1,0 +1,163 @@
+"""3D Moore lattice LGCA implementations."""
+
+import numpy as np
+from lgca.lgca_cubic import (
+    LGCA_Cubic,
+    IBLGCA_Cubic,
+    NoVE_LGCA_Cubic,
+    NoVE_IBLGCA_Cubic,
+)
+
+
+class LGCA_3dMoore(LGCA_Cubic):
+    """Classical LGCA on a 3D Moore lattice."""
+
+    geometry = "moore"
+    velocitychannels = 26
+    velocities = [
+        (dx, dy, dz)
+        for dx in (-1, 0, 1)
+        for dy in (-1, 0, 1)
+        for dz in (-1, 0, 1)
+        if (dx, dy, dz) != (0, 0, 0)
+    ]
+    cix = np.array([v[0] for v in velocities], dtype=float)
+    ciy = np.array([v[1] for v in velocities], dtype=float)
+    ciz = np.array([v[2] for v in velocities], dtype=float)
+    c = np.array([cix, ciy, ciz])
+
+    _vels = velocities
+    _ref_x = {}
+    _ref_y = {}
+    _ref_z = {}
+    for i, (dx, dy, dz) in enumerate(velocities):
+        _ref_x[i] = velocities.index((-dx, dy, dz))
+        _ref_y[i] = velocities.index((dx, -dy, dz))
+        _ref_z[i] = velocities.index((dx, dy, -dz))
+
+    def propagation(self):
+        """Move particles according to their velocity channels."""
+        newnodes = np.zeros_like(self.nodes)
+        newnodes[..., self.velocitychannels :] = self.nodes[..., self.velocitychannels :]
+        for k, (dx, dy, dz) in enumerate(self._vels):
+            src_x = slice(max(-dx, 0), self.nodes.shape[0] - max(dx, 0))
+            dst_x = slice(max(dx, 0), self.nodes.shape[0] - max(-dx, 0))
+            src_y = slice(max(-dy, 0), self.nodes.shape[1] - max(dy, 0))
+            dst_y = slice(max(dy, 0), self.nodes.shape[1] - max(-dy, 0))
+            src_z = slice(max(-dz, 0), self.nodes.shape[2] - max(dz, 0))
+            dst_z = slice(max(dz, 0), self.nodes.shape[2] - max(-dz, 0))
+            newnodes[dst_x, dst_y, dst_z, k] = self.nodes[src_x, src_y, src_z, k]
+        self.nodes = newnodes
+
+    def nb_sum(self, qty):
+        """Sum values of ``qty`` in the 26-neighbourhood of each node."""
+        s = np.zeros_like(qty)
+        for dx, dy, dz in self._vels:
+            src_x = slice(max(-dx, 0), qty.shape[0] - max(dx, 0))
+            dst_x = slice(max(dx, 0), qty.shape[0] - max(-dx, 0))
+            src_y = slice(max(-dy, 0), qty.shape[1] - max(dy, 0))
+            dst_y = slice(max(dy, 0), qty.shape[1] - max(-dy, 0))
+            src_z = slice(max(-dz, 0), qty.shape[2] - max(dz, 0))
+            dst_z = slice(max(dz, 0), qty.shape[2] - max(-dz, 0))
+            s[dst_x, dst_y, dst_z, ...] += qty[src_x, src_y, src_z, ...]
+        return s
+
+    def gradient(self, qty):
+        """Return the spatial gradient of ``qty``."""
+        gx, gy, gz = np.gradient(qty, 0.5)
+        return np.stack((gx, gy, gz), axis=-1)
+
+    def channel_weight(self, qty):
+        """Compute neighbour weights for interaction fields."""
+        w = np.zeros(qty.shape + (self.velocitychannels,))
+        for k, (dx, dy, dz) in enumerate(self._vels):
+            src_x = slice(max(-dx, 0), qty.shape[0] - max(dx, 0))
+            dst_x = slice(max(dx, 0), qty.shape[0] - max(-dx, 0))
+            src_y = slice(max(-dy, 0), qty.shape[1] - max(dy, 0))
+            dst_y = slice(max(dy, 0), qty.shape[1] - max(-dy, 0))
+            src_z = slice(max(-dz, 0), qty.shape[2] - max(dz, 0))
+            dst_z = slice(max(dz, 0), qty.shape[2] - max(-dz, 0))
+            w[dst_x, dst_y, dst_z, k] = qty[src_x, src_y, src_z]
+        return w
+
+    def _apply_rbc_x(self):
+        for i, (dx, _, _) in enumerate(self._vels):
+            j = self._ref_x[i]
+            if dx == -1:
+                self.nodes[self.r_int, :, :, j] += self.nodes[self.r_int - 1, :, :, i]
+            elif dx == 1:
+                self.nodes[-self.r_int - 1, :, :, j] += self.nodes[-self.r_int, :, :, i]
+
+    def _apply_rbc_y(self):
+        for i, (_, dy, _) in enumerate(self._vels):
+            j = self._ref_y[i]
+            if dy == -1:
+                self.nodes[:, self.r_int, :, j] += self.nodes[:, self.r_int - 1, :, i]
+            elif dy == 1:
+                self.nodes[:, -self.r_int - 1, :, j] += self.nodes[:, -self.r_int, :, i]
+
+    def _apply_rbc_z(self):
+        for i, (_, _, dz) in enumerate(self._vels):
+            j = self._ref_z[i]
+            if dz == -1:
+                self.nodes[:, :, self.r_int, j] += self.nodes[:, :, self.r_int - 1, i]
+            elif dz == 1:
+                self.nodes[:, :, -self.r_int - 1, j] += self.nodes[:, :, -self.r_int, i]
+
+    def apply_rbc(self):
+        self._apply_rbc_x()
+        self._apply_rbc_y()
+        self._apply_rbc_z()
+        self.apply_abc()
+
+
+class IBLGCA_Moore(IBLGCA_Cubic, LGCA_3dMoore):
+    """Identity-based LGCA on a 3D Moore lattice."""
+
+
+class NoVE_LGCA_Moore(NoVE_LGCA_Cubic, LGCA_3dMoore):
+    """3D Moore LGCA without volume exclusion."""
+
+    def nb_sum(self, qty):
+        return LGCA_3dMoore.nb_sum(self, qty)
+
+
+class NoVE_IBLGCA_Moore(NoVE_IBLGCA_Cubic, LGCA_3dMoore):
+    """Identity-based 3D Moore LGCA without volume exclusion."""
+
+    def _apply_rbc_x(self):
+        for i, (dx, _, _) in enumerate(self._vels):
+            j = self._ref_x[i]
+            if dx == -1:
+                self.nodes[self.r_int, :, :, j] = (
+                    self.nodes[self.r_int, :, :, j] + self.nodes[self.r_int - 1, :, :, i]
+                )
+            elif dx == 1:
+                self.nodes[-self.r_int - 1, :, :, j] = (
+                    self.nodes[-self.r_int - 1, :, :, j] + self.nodes[-self.r_int, :, :, i]
+                )
+
+    def _apply_rbc_y(self):
+        for i, (_, dy, _) in enumerate(self._vels):
+            j = self._ref_y[i]
+            if dy == -1:
+                self.nodes[:, self.r_int, :, j] = (
+                    self.nodes[:, self.r_int, :, j] + self.nodes[:, self.r_int - 1, :, i]
+                )
+            elif dy == 1:
+                self.nodes[:, -self.r_int - 1, :, j] = (
+                    self.nodes[:, -self.r_int - 1, :, j] + self.nodes[:, -self.r_int, :, i]
+                )
+
+    def _apply_rbc_z(self):
+        for i, (_, _, dz) in enumerate(self._vels):
+            j = self._ref_z[i]
+            if dz == -1:
+                self.nodes[:, :, self.r_int, j] = (
+                    self.nodes[:, :, self.r_int, j] + self.nodes[:, :, self.r_int - 1, i]
+                )
+            elif dz == 1:
+                self.nodes[:, :, -self.r_int - 1, j] = (
+                    self.nodes[:, :, -self.r_int - 1, j] + self.nodes[:, :, -self.r_int, i]
+                )
+

--- a/tests/classical_test.py
+++ b/tests/classical_test.py
@@ -4,6 +4,7 @@ import copy
 import warnings
 
 from lgca import get_lgca
+from lgca.lgca_3dmoore import LGCA_3dMoore
 from tests.common_test import T_LGCA_Common
 
 com = T_LGCA_Common
@@ -382,6 +383,189 @@ def out_cb_dbound(nodes_cb_dbound):
     return expected_output
 
 
+# moore boundary condition fixtures
+@pytest.fixture
+def nodes_mo_rbound():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    nodes[-1, 1, 1, 21] = 1  # +x
+    nodes[-1, 1, 1, 26] = 1  # rest reference
+    nodes[0, 1, 1, 21] = 1   # moving reference
+    return nodes
+
+
+@pytest.fixture
+def out_mo_rbound(nodes_mo_rbound):
+    expected_output = np.zeros(nodes_mo_rbound.shape)
+    expected_output[-1, 1, 1, 26] = 1
+    expected_output[1, 1, 1, 21] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_lbound():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    nodes[0, 1, 1, 4] = 1
+    nodes[0, 1, 1, 26] = 1
+    nodes[2, 1, 1, 4] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_lbound(nodes_mo_lbound):
+    expected_output = np.zeros(nodes_mo_lbound.shape)
+    expected_output[0, 1, 1, 26] = 1
+    expected_output[1, 1, 1, 4] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_tbound():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    nodes[1, -1, 1, 15] = 1
+    nodes[1, -1, 1, 26] = 1
+    nodes[1, 0, 1, 15] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_tbound(nodes_mo_tbound):
+    expected_output = np.zeros(nodes_mo_tbound.shape)
+    expected_output[1, -1, 1, 26] = 1
+    expected_output[1, 1, 1, 15] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_bbound():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    nodes[1, 0, 1, 10] = 1
+    nodes[1, 0, 1, 26] = 1
+    nodes[1, 2, 1, 10] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_bbound(nodes_mo_bbound):
+    expected_output = np.zeros(nodes_mo_bbound.shape)
+    expected_output[1, 0, 1, 26] = 1
+    expected_output[1, 1, 1, 10] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_ubound():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    nodes[1, 1, -1, 13] = 1
+    nodes[1, 1, -1, 26] = 1
+    nodes[1, 1, 0, 13] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_ubound(nodes_mo_ubound):
+    expected_output = np.zeros(nodes_mo_ubound.shape)
+    expected_output[1, 1, -1, 26] = 1
+    expected_output[1, 1, 1, 13] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_dbound():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    nodes[1, 1, 0, 12] = 1
+    nodes[1, 1, 0, 26] = 1
+    nodes[1, 1, 2, 12] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_dbound(nodes_mo_dbound):
+    expected_output = np.zeros(nodes_mo_dbound.shape)
+    expected_output[1, 1, 0, 26] = 1
+    expected_output[1, 1, 1, 12] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_edge_xy():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    idx = LGCA_3dMoore.velocities.index((1, 1, 0))
+    nodes[-1, -1, 1, idx] = 1
+    nodes[-1, -1, 1, 26] = 1
+    nodes[1, 1, 1, idx] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_edge_xy_pbc(nodes_mo_edge_xy):
+    expected_output = np.zeros(nodes_mo_edge_xy.shape)
+    idx = LGCA_3dMoore.velocities.index((1, 1, 0))
+    expected_output[-1, -1, 1, 26] = 1
+    expected_output[0, 0, 1, idx] = 1
+    expected_output[2, 2, 1, idx] = 1
+    return expected_output
+
+
+@pytest.fixture
+def out_mo_edge_xy_rbc(nodes_mo_edge_xy):
+    expected_output = np.zeros(nodes_mo_edge_xy.shape)
+    idx = LGCA_3dMoore.velocities.index((1, 1, 0))
+    idx_ref = LGCA_3dMoore.velocities.index((-1, -1, 0))
+    expected_output[-1, -1, 1, 26] = 1
+    expected_output[2, 2, 1, idx] = 1
+    expected_output[2, 2, 1, idx_ref] = 1
+    return expected_output
+
+
+@pytest.fixture
+def out_mo_edge_xy_abc(nodes_mo_edge_xy):
+    expected_output = np.zeros(nodes_mo_edge_xy.shape)
+    idx = LGCA_3dMoore.velocities.index((1, 1, 0))
+    expected_output[-1, -1, 1, 26] = 1
+    expected_output[2, 2, 1, idx] = 1
+    return expected_output
+
+
+@pytest.fixture
+def nodes_mo_corner_xyz():
+    nodes = np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore + 1))
+    idx = LGCA_3dMoore.velocities.index((1, 1, 1))
+    nodes[-1, -1, -1, idx] = 1
+    nodes[-1, -1, -1, 26] = 1
+    nodes[1, 1, 1, idx] = 1
+    return nodes
+
+
+@pytest.fixture
+def out_mo_corner_xyz_pbc(nodes_mo_corner_xyz):
+    expected_output = np.zeros(nodes_mo_corner_xyz.shape)
+    idx = LGCA_3dMoore.velocities.index((1, 1, 1))
+    expected_output[-1, -1, -1, 26] = 1
+    expected_output[0, 0, 0, idx] = 1
+    expected_output[2, 2, 2, idx] = 1
+    return expected_output
+
+
+@pytest.fixture
+def out_mo_corner_xyz_rbc(nodes_mo_corner_xyz):
+    expected_output = np.zeros(nodes_mo_corner_xyz.shape)
+    idx = LGCA_3dMoore.velocities.index((1, 1, 1))
+    idx_ref = LGCA_3dMoore.velocities.index((-1, -1, -1))
+    expected_output[-1, -1, -1, 26] = 1
+    expected_output[2, 2, 2, idx] = 1
+    expected_output[2, 2, 2, idx_ref] = 1
+    return expected_output
+
+
+@pytest.fixture
+def out_mo_corner_xyz_abc(nodes_mo_corner_xyz):
+    expected_output = np.zeros(nodes_mo_corner_xyz.shape)
+    idx = LGCA_3dMoore.velocities.index((1, 1, 1))
+    expected_output[-1, -1, -1, 26] = 1
+    expected_output[2, 2, 2, idx] = 1
+    return expected_output
+
+
 class Test_LGCA_classical(T_LGCA_Common):
     """
     Class for testing classical LGCA (volume exclusion, not identity-based).
@@ -399,7 +583,8 @@ class Test_LGCA_classical(T_LGCA_Common):
         ('lin', (com.xdim_1d,)),
         ('square', (com.xdim_square, com.ydim_square)),
         ('hex', (com.xdim_hex, com.ydim_hex)),
-        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
+        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic)),
+        ('moore', (com.xdim_moore, com.ydim_moore, com.zdim_moore))
     ])
     def test_recording(self, geom, dims):
         # timeevo and recording: check if all properties are available when requested
@@ -490,6 +675,34 @@ class Test_LGCA_classical(T_LGCA_Common):
         expected_output = np.zeros((self.xdim_cubic, self.ydim_cubic, self.zdim_cubic, restchannels + self.b_cubic))
         expected_output[1, 1, 1, 0:7] = 1
         self.t_propagation_template('cubic', nodes, expected_output)
+
+        # 3D moore
+        restchannels = 2
+        nodes = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, restchannels + self.b_moore))
+        nodes[0, 1, 1, 21] = 1  # +x
+        nodes[2, 1, 1, 4] = 1   # -x
+        nodes[1, 0, 1, 15] = 1  # +y
+        nodes[1, 2, 1, 10] = 1  # -y
+        nodes[1, 1, 0, 13] = 1  # +z
+        nodes[1, 1, 2, 12] = 1  # -z
+        nodes[1, 1, 1, 26] = 1  # rest
+        expected_output = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, restchannels + self.b_moore))
+        expected_output[1, 1, 1, [21,4,15,10,13,12,26]] = 1
+        self.t_propagation_template('moore', nodes, expected_output)
+
+    def test_propagation_moore_all_channels(self):
+        restchannels = 2
+        nodes = np.zeros(
+            (self.xdim_moore, self.ydim_moore, self.zdim_moore, restchannels + self.b_moore),
+            dtype=bool,
+        )
+        center = (1, 1, 1)
+        for idx, (dx, dy, dz) in enumerate(LGCA_3dMoore.velocities):
+            nodes[center[0] - dx, center[1] - dy, center[2] - dz, idx] = True
+        nodes[center][self.b_moore :] = True
+        expected = np.zeros_like(nodes)
+        expected[center] = True
+        self.t_propagation_template('moore', nodes, expected)
 
     def test_pbc_1d(self, nodes_1d_rbound, out_1d_rbound, nodes_1d_lbound, out_1d_lbound):
         # check periodic boundary conditions in 1D
@@ -708,18 +921,76 @@ class Test_LGCA_classical(T_LGCA_Common):
         self.t_propagation_template('cubic', nodes_cb_ubound, out_cb_ubound, bc='abc')
         self.t_propagation_template('cubic', nodes_cb_dbound, out_cb_dbound, bc='abc')
 
+    def test_pbc_moore(self, nodes_mo_rbound, out_mo_rbound, nodes_mo_lbound, out_mo_lbound,
+                       nodes_mo_tbound, out_mo_tbound, nodes_mo_bbound, out_mo_bbound,
+                       nodes_mo_ubound, out_mo_ubound, nodes_mo_dbound, out_mo_dbound):
+        out_mo_rbound[0, 1, 1, 21] = 1
+        out_mo_lbound[-1, 1, 1, 4] = 1
+        out_mo_tbound[1, 0, 1, 15] = 1
+        out_mo_bbound[1, -1, 1, 10] = 1
+        out_mo_ubound[1, 1, 0, 13] = 1
+        out_mo_dbound[1, 1, 2, 12] = 1
+        self.t_propagation_template('moore', nodes_mo_rbound, out_mo_rbound, bc='pbc')
+        self.t_propagation_template('moore', nodes_mo_lbound, out_mo_lbound, bc='pbc')
+        self.t_propagation_template('moore', nodes_mo_tbound, out_mo_tbound, bc='pbc')
+        self.t_propagation_template('moore', nodes_mo_bbound, out_mo_bbound, bc='pbc')
+        self.t_propagation_template('moore', nodes_mo_ubound, out_mo_ubound, bc='pbc')
+        self.t_propagation_template('moore', nodes_mo_dbound, out_mo_dbound, bc='pbc')
+
+    def test_rbc_moore(self, nodes_mo_rbound, out_mo_rbound, nodes_mo_lbound, out_mo_lbound,
+                       nodes_mo_tbound, out_mo_tbound, nodes_mo_bbound, out_mo_bbound,
+                       nodes_mo_ubound, out_mo_ubound, nodes_mo_dbound, out_mo_dbound):
+        out_mo_rbound[-1, 1, 1, 4] = 1
+        out_mo_lbound[0, 1, 1, 21] = 1
+        out_mo_tbound[1, -1, 1, 10] = 1
+        out_mo_bbound[1, 0, 1, 15] = 1
+        out_mo_ubound[1, 1, -1, 12] = 1
+        out_mo_dbound[1, 1, 0, 13] = 1
+        self.t_propagation_template('moore', nodes_mo_rbound, out_mo_rbound, bc='rbc')
+        self.t_propagation_template('moore', nodes_mo_lbound, out_mo_lbound, bc='rbc')
+        self.t_propagation_template('moore', nodes_mo_tbound, out_mo_tbound, bc='rbc')
+        self.t_propagation_template('moore', nodes_mo_bbound, out_mo_bbound, bc='rbc')
+        self.t_propagation_template('moore', nodes_mo_ubound, out_mo_ubound, bc='rbc')
+        self.t_propagation_template('moore', nodes_mo_dbound, out_mo_dbound, bc='rbc')
+
+    def test_abc_moore(self, nodes_mo_rbound, out_mo_rbound, nodes_mo_lbound, out_mo_lbound,
+                       nodes_mo_tbound, out_mo_tbound, nodes_mo_bbound, out_mo_bbound,
+                       nodes_mo_ubound, out_mo_ubound, nodes_mo_dbound, out_mo_dbound):
+        self.t_propagation_template('moore', nodes_mo_rbound, out_mo_rbound, bc='abc')
+        self.t_propagation_template('moore', nodes_mo_lbound, out_mo_lbound, bc='abc')
+        self.t_propagation_template('moore', nodes_mo_tbound, out_mo_tbound, bc='abc')
+        self.t_propagation_template('moore', nodes_mo_bbound, out_mo_bbound, bc='abc')
+        self.t_propagation_template('moore', nodes_mo_ubound, out_mo_ubound, bc='abc')
+        self.t_propagation_template('moore', nodes_mo_dbound, out_mo_dbound, bc='abc')
+
+    def test_edge_conditions_moore_pbc(self, nodes_mo_edge_xy, out_mo_edge_xy_pbc,
+                                      nodes_mo_corner_xyz, out_mo_corner_xyz_pbc):
+        self.t_propagation_template('moore', nodes_mo_edge_xy, out_mo_edge_xy_pbc, bc='pbc')
+        self.t_propagation_template('moore', nodes_mo_corner_xyz, out_mo_corner_xyz_pbc, bc='pbc')
+
+    def test_edge_conditions_moore_rbc(self, nodes_mo_edge_xy, out_mo_edge_xy_rbc,
+                                      nodes_mo_corner_xyz, out_mo_corner_xyz_rbc):
+        self.t_propagation_template('moore', nodes_mo_edge_xy, out_mo_edge_xy_rbc, bc='rbc')
+        self.t_propagation_template('moore', nodes_mo_corner_xyz, out_mo_corner_xyz_rbc, bc='rbc')
+
+    def test_edge_conditions_moore_abc(self, nodes_mo_edge_xy, out_mo_edge_xy_abc,
+                                      nodes_mo_corner_xyz, out_mo_corner_xyz_abc):
+        self.t_propagation_template('moore', nodes_mo_edge_xy, out_mo_edge_xy_abc, bc='abc')
+        self.t_propagation_template('moore', nodes_mo_corner_xyz, out_mo_corner_xyz_abc, bc='abc')
+
     @pytest.mark.parametrize("geom,nodes", [
         ('lin', com.nodes_ve_1d),
         ('square', com.nodes_ve_square),
         ('hex', com.nodes_ve_hex),
-        ('cubic', com.nodes_ve_cubic)
+        ('cubic', com.nodes_ve_cubic),
+        ('moore', com.nodes_ve_moore)
     ])
     def test_characteristics(self, geom, nodes):
         # test compliance in all interactions to:
         # * volume exclusion principle
         ref_lgca = get_lgca(geometry=geom, ve=self.ve, ib=self.ib)
         for interaction in ref_lgca.interactions:
-            if geom == 'cubic' and interaction == 'contact_guidance':
+            if geom in {'cubic', 'moore'} and interaction == 'contact_guidance':
                 continue
             # test all boundary conditions in case of abuse of border nodes
             self.t_characteristics(geom, nodes, interaction, 'pbc')

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -41,6 +41,11 @@ class T_LGCA_Common(ABC):
     xdim_cubic = 3
     ydim_cubic = 3
     zdim_cubic = 3
+    # 3D moore
+    b_moore = 26
+    xdim_moore = 3
+    ydim_moore = 3
+    zdim_moore = 3
 
     # classical parameters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # 1D
@@ -63,6 +68,15 @@ class T_LGCA_Common(ABC):
     K_ve_cubic = b_cubic + restchannels_ve_cubic
     nodes_ve_cubic = rng.integers(low=0, high=1, endpoint=True,
                                   size=(xdim_cubic, ydim_cubic, zdim_cubic, b_cubic + restchannels_ve_cubic))
+    # 3D moore
+    restchannels_ve_moore = 2
+    K_ve_moore = b_moore + restchannels_ve_moore
+    nodes_ve_moore = rng.integers(
+        low=0,
+        high=1,
+        endpoint=True,
+        size=(xdim_moore, ydim_moore, zdim_moore, b_moore + restchannels_ve_moore),
+    )
 
     # ib parameters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # reuses some classical parameters
@@ -96,6 +110,21 @@ class T_LGCA_Common(ABC):
     rng.shuffle(nodes_ib_cubic)
     nodes_ib_cubic = nodes_ib_cubic.reshape((xdim_cubic, ydim_cubic, zdim_cubic,
                                             b_cubic + restchannels_ve_cubic))
+    # 3D moore
+    no_particles_moore = rng.integers(
+        low=1,
+        high=(xdim_moore * ydim_moore * zdim_moore * (b_moore + restchannels_ve_moore)),
+        endpoint=True,
+        size=1,
+    )
+    nodes_ib_moore = np.append(
+        np.arange(no_particles_moore) + 1,
+        np.zeros(xdim_moore * ydim_moore * zdim_moore * (b_moore + restchannels_ve_moore) - no_particles_moore),
+    )
+    rng.shuffle(nodes_ib_moore)
+    nodes_ib_moore = nodes_ib_moore.reshape(
+        (xdim_moore, ydim_moore, zdim_moore, b_moore + restchannels_ve_moore)
+    )
 
     # nove parameters ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     # nodes must be defined in the correct size! Maximum size of last dimension = b+1
@@ -119,6 +148,15 @@ class T_LGCA_Common(ABC):
     capacity_nove_cubic = 7
     nodes_nove_cubic = rng.integers(low=0, high=int(1.5 * capacity_nove_cubic),
                                     size=(xdim_cubic, ydim_cubic, zdim_cubic, b_cubic + 1), endpoint=True)
+    # 3D moore
+    restchannels_nove_moore = 1
+    capacity_nove_moore = b_moore + restchannels_nove_moore
+    nodes_nove_moore = rng.integers(
+        low=0,
+        high=int(1.5 * capacity_nove_moore),
+        size=(xdim_moore, ydim_moore, zdim_moore, b_moore + 1),
+        endpoint=True,
+    )
 
     def t_propagation_template(self, geom, nodes, expected_output, bc='pbc'):
         # check that propagation and rest channels work: all particles should move into one node within one timestep
@@ -167,18 +205,21 @@ class Test_LGCA_General:
         ('square',  True, False, com.nodes_ve_square,   (com.xdim_square, com.ydim_square), com.restchannels_ve_square),
         ('hex',     True, False, com.nodes_ve_hex,      (com.xdim_hex, com.ydim_hex),       com.restchannels_ve_hex),
         ('cubic',   True, False, com.nodes_ve_cubic,    (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_ve_cubic),
+        ('moore',   True, False, com.nodes_ve_moore,   (com.xdim_moore, com.ydim_moore, com.zdim_moore), com.restchannels_ve_moore),
         # IBLGCA (ve, ib)
         # (geom,    ve,   ib,   nodes,                  dims,                               restchannels)
         ('lin',     True, True, com.nodes_ib_1d,        (com.xdim_1d,),                     com.restchannels_ve_1d),
         ('square',  True, True, com.nodes_ib_square,    (com.xdim_square, com.ydim_square), com.restchannels_ve_square),
         ('hex',     True, True, com.nodes_ib_hex,       (com.xdim_hex, com.ydim_hex),       com.restchannels_ve_hex),
         ('cubic',   True, True, com.nodes_ib_cubic,     (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), com.restchannels_ve_cubic),
+        ('moore',   True, True, com.nodes_ib_moore,    (com.xdim_moore, com.ydim_moore, com.zdim_moore), com.restchannels_ve_moore),
         # NoVE_LGCA (nove, non-ib)
         # (geom,    ve,    ib,    nodes,                    dims,                               restchannels)
         ('lin',     False, False, com.nodes_nove_1d,        (com.xdim_1d,),                     1),
         ('square',  False, False, com.nodes_nove_square,    (com.xdim_square, com.ydim_square), 1),
         ('hex',     False, False, com.nodes_nove_hex,       (com.xdim_hex, com.ydim_hex),       1),
-        ('cubic',   False, False, com.nodes_nove_cubic,     (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), 1)
+        ('cubic',   False, False, com.nodes_nove_cubic,     (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic), 1),
+        ('moore',   False, False, com.nodes_nove_moore,    (com.xdim_moore, com.ydim_moore, com.zdim_moore), 1)
     ])
     def test_getlgca_lattice_setup_nodes(self, geom, ve, ib, nodes, dims, restchannels):
         # 'node' keyword check: provided lattice is adopted by LGCA
@@ -219,6 +260,7 @@ class Test_LGCA_General:
         ('square', np.zeros((com.xdim_square, com.ydim_square, com.b_square - 1), dtype=bool)),
         ('hex', np.zeros((com.xdim_hex, com.ydim_hex, com.b_hex - 1), dtype=bool)),
         ('cubic', np.zeros((com.xdim_cubic, com.ydim_cubic, com.zdim_cubic, com.b_cubic - 1), dtype=bool)),
+        ('moore', np.zeros((com.xdim_moore, com.ydim_moore, com.zdim_moore, com.b_moore - 1), dtype=bool)),
     ])
     def test_nodes_too_few_channels(self, geom, nodes):
         with pytest.raises(RuntimeError):
@@ -231,12 +273,14 @@ class Test_LGCA_General:
         ('square',  True, False, (20, 20),      com.restchannels_ve_square,    density_ve, com.K_ve_square),
         ('hex',     True, False, (20, 20),      com.restchannels_ve_hex,       density_ve, com.K_ve_hex),
         ('cubic',   True, False, (5, 5, 5),     com.restchannels_ve_cubic,    density_ve, com.K_ve_cubic),
+        ('moore',   True, False, (5, 5, 5),     com.restchannels_ve_moore,   density_ve, com.K_ve_moore),
         # IBLGCA (ve, ib)
         # (geom,    ve,   ib,   dims_large,    restchannels,                density,    capacity)
         ('lin',     True, True, (400,),        com.restchannels_ve_1d,      density_ve, com.K_ve_1d),
         ('square',  True, True, (20, 20),      com.restchannels_ve_square,  density_ve, com.K_ve_square),
         ('hex',     True, True, (20, 20),      com.restchannels_ve_hex,     density_ve, com.K_ve_hex),
         ('cubic',   True, True, (5, 5, 5),     com.restchannels_ve_cubic,   density_ve, com.K_ve_cubic),
+        ('moore',   True, True, (5, 5, 5),     com.restchannels_ve_moore,  density_ve, com.K_ve_moore),
         # NoVE_LGCA (nove, non-ib)
         # written assuming that capacity for nove is set to velocitychannels + restchannels
         # (geom,   ve,    ib,    dims_large,   restchannels,                 density,        capacity)
@@ -244,11 +288,13 @@ class Test_LGCA_General:
         ('square', False, False, (20, 20),     com.restchannels_nove_square, density_nove_1, com.b_square+com.restchannels_nove_square),
         ('hex',    False, False, (20, 20),     com.restchannels_nove_hex,    density_nove_1, com.b_hex+com.restchannels_nove_hex),
         ('cubic',  False, False, (5, 5, 5),    com.restchannels_nove_cubic, density_nove_1, com.b_cubic+com.restchannels_nove_cubic),
+        ('moore',  False, False, (5, 5, 5),    com.restchannels_nove_moore, density_nove_1, com.b_moore+com.restchannels_nove_moore),
         # (geom,   ve,    ib,    dims_large,   restchannels,                 density,        capacity)
         ('lin',    False, False, (400,),       com.restchannels_nove_1d,     density_nove_2, com.b_1d+com.restchannels_nove_1d),
         ('square', False, False, (20, 20),     com.restchannels_nove_square, density_nove_2, com.b_square+com.restchannels_nove_square),
         ('hex',    False, False, (20, 20),     com.restchannels_nove_hex,    density_nove_2, com.b_hex+com.restchannels_nove_hex)
-        ,('cubic', False, False, (5, 5, 5),    com.restchannels_nove_cubic, density_nove_2, com.b_cubic+com.restchannels_nove_cubic)
+        ,('cubic', False, False, (5, 5, 5),    com.restchannels_nove_cubic, density_nove_2, com.b_cubic+com.restchannels_nove_cubic),
+        ('moore',  False, False, (5, 5, 5),    com.restchannels_nove_moore, density_nove_2, com.b_moore+com.restchannels_nove_moore)
     ])
     def test_getlgca_lattice_setup_random(self, geom, ve, ib, dims_large, restchannels, density, capacity):
         # 'density' keyword check, random reset

--- a/tests/ib_test.py
+++ b/tests/ib_test.py
@@ -19,6 +19,7 @@ def matching_import(pattern, module, globals):
 
 
 from lgca import get_lgca
+from lgca.lgca_3dmoore import LGCA_3dMoore
 # import other test modules for fixture and function reuse
 # CAUTION: they need to be renamed and lose the "Test" prefix so that pytest does not executes these tests again
 from tests.common_test import T_LGCA_Common
@@ -60,12 +61,16 @@ class Test_LGCA_IB(T_LGCA_Common):
     test_pbc_cubic = T_LGCA_classical.test_pbc_cubic
     test_rbc_cubic = T_LGCA_classical.test_rbc_cubic
     test_abc_cubic = T_LGCA_classical.test_abc_cubic
+    test_pbc_moore = T_LGCA_classical.test_pbc_moore
+    test_rbc_moore = T_LGCA_classical.test_rbc_moore
+    test_abc_moore = T_LGCA_classical.test_abc_moore
 
     @pytest.mark.parametrize("geom,dims", [
         ('lin', (com.xdim_1d,)),
         ('square', (com.xdim_square, com.ydim_square)),
         ('hex', (com.xdim_hex, com.ydim_hex)),
-        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
+        ('cubic', (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic)),
+        ('moore', (com.xdim_moore, com.ydim_moore, com.zdim_moore))
     ])
     def test_recording(self, geom, dims):
         # timeevo and recording: check if all properties are available when requested
@@ -167,11 +172,40 @@ class Test_LGCA_IB(T_LGCA_Common):
         expected_output[1, 1, 1, 6] = 7
         self.t_propagation_template('cubic', nodes, expected_output)
 
+        # 3D moore
+        restchannels = 2
+        nodes = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, self.b_moore + restchannels))
+        nodes[0, 1, 1, 21] = 1  # +x
+        nodes[2, 1, 1, 4] = 2   # -x
+        nodes[1, 0, 1, 15] = 3  # +y
+        nodes[1, 2, 1, 10] = 4  # -y
+        nodes[1, 1, 0, 13] = 5  # +z
+        nodes[1, 1, 2, 12] = 6  # -z
+        nodes[1, 1, 1, 26] = 7  # rest
+        expected_output = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, self.b_moore + restchannels))
+        expected_output[1, 1, 1, [21, 4, 15, 10, 13, 12, 26]] = [1, 2, 3, 4, 5, 6, 7]
+        self.t_propagation_template('moore', nodes, expected_output)
+
+    def test_propagation_moore_all_channels(self):
+        restchannels = 2
+        nodes = np.zeros(
+            (self.xdim_moore, self.ydim_moore, self.zdim_moore, restchannels + self.b_moore),
+            dtype=bool,
+        )
+        center = (1, 1, 1)
+        for idx, (dx, dy, dz) in enumerate(LGCA_3dMoore.velocities):
+            nodes[center[0] - dx, center[1] - dy, center[2] - dz, idx] = True
+        nodes[center][self.b_moore :] = True
+        expected = np.zeros_like(nodes)
+        expected[center] = True
+        self.t_propagation_template('moore', nodes, expected)
+
     @pytest.mark.parametrize("geom,nodes", [
         ('lin', com.nodes_ib_1d),
         ('square', com.nodes_ib_square),
         ('hex', com.nodes_ib_hex),
-        ('cubic', com.nodes_ib_cubic)
+        ('cubic', com.nodes_ib_cubic),
+        ('moore', com.nodes_ib_moore)
     ])
     def test_characteristics(self, geom, nodes):
         # test compliance in all interactions to:

--- a/tests/nove_ib_test.py
+++ b/tests/nove_ib_test.py
@@ -5,6 +5,7 @@ import pytest
 
 pytest.importorskip("numba")
 from lgca import get_lgca
+from lgca.lgca_3dmoore import LGCA_3dMoore
 from tests.common_test import T_LGCA_Common
 from tests.classical_test import Test_LGCA_classical as T_LGCA_classical
 import tests.classical_test
@@ -247,6 +248,9 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
     test_pbc_cubic = T_LGCA_classical.test_pbc_cubic
     test_rbc_cubic = T_LGCA_classical.test_rbc_cubic
     test_abc_cubic = T_LGCA_classical.test_abc_cubic
+    test_pbc_moore = T_LGCA_classical.test_pbc_moore
+    test_rbc_moore = T_LGCA_classical.test_rbc_moore
+    test_abc_moore = T_LGCA_classical.test_abc_moore
 
     def t_prop_counts_template(self, geom, nodes, expected, bc="pbc"):
         nodes_ib = counts_to_lists(nodes)
@@ -268,7 +272,8 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
         ("lin", (com.xdim_1d,)),
         ("square", (com.xdim_square, com.ydim_square)),
         ("hex", (com.xdim_hex, com.ydim_hex)),
-        ("cubic", (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic))
+        ("cubic", (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic)),
+        ("moore", (com.xdim_moore, com.ydim_moore, com.zdim_moore))
     ])
     def test_recording(self, geom, dims):
         lgca_1 = get_lgca(geometry=geom, ve=False, ib=True, dims=dims, density=0.5, interaction="only_propagation")
@@ -353,11 +358,39 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
         expected[1, 1, 6] = 7
         self.t_prop_counts_template("hex", nodes, expected)
 
+        # 3D moore
+        nodes = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, self.b_moore + 1), dtype=int)
+        nodes[0, 1, 1, 21] = 1
+        nodes[2, 1, 1, 4] = 2
+        nodes[1, 0, 1, 15] = 3
+        nodes[1, 2, 1, 10] = 4
+        nodes[1, 1, 0, 13] = 5
+        nodes[1, 1, 2, 12] = 6
+        nodes[1, 1, 1, 26] = 7
+        expected = np.zeros_like(nodes)
+        expected[1, 1, 1, [21, 4, 15, 10, 13, 12, 26]] = [1, 2, 3, 4, 5, 6, 7]
+        self.t_prop_counts_template("moore", nodes, expected)
+
+    def test_propagation_moore_all_channels(self):
+        restchannels = 2
+        nodes = np.zeros(
+            (self.xdim_moore, self.ydim_moore, self.zdim_moore, restchannels + self.b_moore),
+            dtype=int,
+        )
+        center = (1, 1, 1)
+        for idx, (dx, dy, dz) in enumerate(LGCA_3dMoore.velocities):
+            nodes[center[0] - dx, center[1] - dy, center[2] - dz, idx] = 1
+        nodes[center][self.b_moore:] = 1
+        expected = np.zeros_like(nodes)
+        expected[center] = 1
+        self.t_prop_counts_template("moore", nodes, expected)
+
     @pytest.mark.parametrize("geom,nodes,b", [
         ("lin", com.nodes_nove_1d, com.b_1d),
         ("square", com.nodes_nove_square, com.b_square),
         ("hex", com.nodes_nove_hex, com.b_hex),
-        ("cubic", com.nodes_nove_cubic, com.b_cubic)
+        ("cubic", com.nodes_nove_cubic, com.b_cubic),
+        ("moore", com.nodes_nove_moore, com.b_moore)
     ])
     def test_getlgca_capacity(self, geom, nodes, b):
         capacity = 10
@@ -382,13 +415,14 @@ class Test_LGCA_NoVE_IB(T_LGCA_Common):
         ("lin", com.nodes_nove_1d),
         ("square", com.nodes_nove_square),
         ("hex", com.nodes_nove_hex),
-        ("cubic", com.nodes_nove_cubic)
+        ("cubic", com.nodes_nove_cubic),
+        ("moore", com.nodes_nove_moore)
     ])
     def test_characteristics(self, geom, nodes):
         nodes_ib = counts_to_lists(nodes)
         ref_lgca = get_lgca(geometry=geom, ve=self.ve, ib=self.ib)
         for interaction in ref_lgca.interactions:
-            if geom == "cubic" and interaction == "contact_guidance":
+            if geom in {"cubic", "moore"} and interaction == "contact_guidance":
                 continue
             self.t_characteristics(geom, nodes_ib, interaction, "pbc")
             self.t_characteristics(geom, nodes_ib, interaction, "rbc")

--- a/tests/nove_test.py
+++ b/tests/nove_test.py
@@ -3,6 +3,7 @@ import pytest
 import copy
 
 from lgca import get_lgca
+from lgca.lgca_3dmoore import LGCA_3dMoore
 from tests.common_test import T_LGCA_Common
 from tests.classical_test import (
     Test_LGCA_classical as T_LGCA_classical,  # rename to avoid duplicate execution of these tests
@@ -338,6 +339,9 @@ class Test_LGCA_NoVE(T_LGCA_Common):
     test_pbc_cubic = T_LGCA_classical.test_pbc_cubic
     test_rbc_cubic = T_LGCA_classical.test_rbc_cubic
     test_abc_cubic = T_LGCA_classical.test_abc_cubic
+    test_pbc_moore = T_LGCA_classical.test_pbc_moore
+    test_rbc_moore = T_LGCA_classical.test_rbc_moore
+    test_abc_moore = T_LGCA_classical.test_abc_moore
 
     @pytest.mark.parametrize(
         "geom,dims",
@@ -346,6 +350,7 @@ class Test_LGCA_NoVE(T_LGCA_Common):
             ("square", (com.xdim_square, com.ydim_square)),
             ("hex", (com.xdim_hex, com.ydim_hex)),
             ("cubic", (com.xdim_cubic, com.ydim_cubic, com.zdim_cubic)),
+            ("moore", (com.xdim_moore, com.ydim_moore, com.zdim_moore)),
         ],
     )
     def test_recording(self, geom, dims):
@@ -466,6 +471,34 @@ class Test_LGCA_NoVE(T_LGCA_Common):
         expected_output[1, 1, 6] = 7  # particles resting
         self.t_propagation_template("hex", nodes, expected_output)
 
+        # 3D moore
+        restchannels = 2
+        nodes = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, self.b_moore + restchannels))
+        nodes[0, 1, 1, 21] = 1
+        nodes[2, 1, 1, 4] = 2
+        nodes[1, 0, 1, 15] = 3
+        nodes[1, 2, 1, 10] = 4
+        nodes[1, 1, 0, 13] = 5
+        nodes[1, 1, 2, 12] = 6
+        nodes[1, 1, 1, 26] = 7
+        expected_output = np.zeros((self.xdim_moore, self.ydim_moore, self.zdim_moore, self.b_moore + restchannels))
+        expected_output[1, 1, 1, [21, 4, 15, 10, 13, 12, 26]] = [1, 2, 3, 4, 5, 6, 7]
+        self.t_propagation_template("moore", nodes, expected_output)
+
+    def test_propagation_moore_all_channels(self):
+        restchannels = 2
+        nodes = np.zeros(
+            (self.xdim_moore, self.ydim_moore, self.zdim_moore, restchannels + self.b_moore),
+            dtype=bool,
+        )
+        center = (1, 1, 1)
+        for idx, (dx, dy, dz) in enumerate(LGCA_3dMoore.velocities):
+            nodes[center[0] - dx, center[1] - dy, center[2] - dz, idx] = True
+        nodes[center][self.b_moore :] = True
+        expected = np.zeros_like(nodes)
+        expected[center] = True
+        self.t_propagation_template("moore", nodes, expected)
+
     @pytest.mark.parametrize(
         "geom,nodes,b",
         [
@@ -473,6 +506,7 @@ class Test_LGCA_NoVE(T_LGCA_Common):
             ("square", com.nodes_nove_square, com.b_square),
             ("hex", com.nodes_nove_hex, com.b_hex),
             ("cubic", com.nodes_nove_cubic, com.b_cubic),
+            ("moore", com.nodes_nove_moore, com.b_moore),
         ],
     )
     def test_getlgca_capacity(self, geom, nodes, b):

--- a/tests/test_get_lgca.py
+++ b/tests/test_get_lgca.py
@@ -11,6 +11,12 @@ from lgca.lgca_cubic import (
     NoVE_LGCA_Cubic,
     NoVE_IBLGCA_Cubic,
 )
+from lgca.lgca_3dmoore import (
+    LGCA_3dMoore,
+    IBLGCA_Moore,
+    NoVE_LGCA_Moore,
+    NoVE_IBLGCA_Moore,
+)
 
 EXPECTED = {
     'lin': {
@@ -37,9 +43,15 @@ EXPECTED = {
         (False, False): NoVE_LGCA_Cubic,
         (True, False): NoVE_IBLGCA_Cubic,
     },
+    'moore': {
+        (False, True): LGCA_3dMoore,
+        (True, True): IBLGCA_Moore,
+        (False, False): NoVE_LGCA_Moore,
+        (True, False): NoVE_IBLGCA_Moore,
+    },
 }
 
-geometries = ['lin', 'square', 'hex', 'cubic']
+geometries = ['lin', 'square', 'hex', 'cubic', 'moore']
 
 PARAMS = [
     (g, ib, ve)

--- a/tests/test_repr.py
+++ b/tests/test_repr.py
@@ -7,10 +7,18 @@ except Exception:
     HAS_CUBIC = False
 else:
     HAS_CUBIC = True
+try:
+    from lgca.lgca_3dmoore import LGCA_3dMoore  # noqa: F401
+except Exception:
+    HAS_MOORE = False
+else:
+    HAS_MOORE = True
 
 geometries = ['lin', 'square', 'hex']
 if HAS_CUBIC:
     geometries.append('cubic')
+if HAS_MOORE:
+    geometries.append('moore')
 
 @pytest.mark.parametrize('geom', geometries)
 def test_repr_and_str(geom):


### PR DESCRIPTION
## Summary
- add propagation checks for 3D Moore lattice to IB, NoVE and NoVE+IB tests
- verify all 26 velocity directions for each model

## Testing Done
- `pytest -q`
- `pytest tests/ib_test.py::Test_LGCA_IB::test_propagation_moore_all_channels -q`
- `pytest tests/nove_test.py::Test_LGCA_NoVE::test_propagation_moore_all_channels -q`


------
https://chatgpt.com/codex/tasks/task_e_6845c565179c8333a489ec2711bcf546