### PR TITLE
[Fix] avoid numpy scalar conversion warning

### DIFF
--- a/lgca/ib_interactions.py
+++ b/lgca/ib_interactions.py
@@ -53,12 +53,15 @@ def trunc_gauss(lower, upper, mu, sigma=.1, size=1):
 
     Returns
     -------
-    :class:`numpy.ndarray`
-        Array of samples from the truncated distribution.
+    float or :class:`numpy.ndarray`
+        ``float`` if ``size`` equals ``1`` or an array of samples otherwise.
     """
     a = (lower - mu) / sigma
     b = (upper - mu) / sigma
-    return truncnorm(a, b, loc=mu, scale=sigma).rvs(size)
+    vals = truncnorm(a, b, loc=mu, scale=sigma).rvs(size)
+    if size != 1:
+        return vals
+    return float(np.asarray(vals).item())
 
 def birth(lgca):
     """Create daughter cells according to individual proliferation rates.


### PR DESCRIPTION
## Summary
- update truncation helper in ib_interactions to return float for single draws

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849d6879fd88333ab57e06bc1a65b52