### PR TITLE
[Docs] Refresh LGCA module headers

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -164,7 +164,7 @@ License
 
 BSD 3-clause license (see LICENSE file or `online resource <https://opensource.org/licenses/BSD-3-Clause>`_).
 
-Copyright (C) 2018-2024 Technische Universität Dresden.
+Copyright (C) 2018-2025 Technische Universität Dresden.
 
 
 .. toctree::

--- a/lgca/__init__.py
+++ b/lgca/__init__.py
@@ -2,10 +2,8 @@
 # cellular automata (LGCA) in the biological context.
 # It is made available under the BSD 3-clause license (see LICENSE.txt or
 # https://opensource.org/licenses/BSD-3-Clause).
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # Contact: simon.syga@tu-dresden.de or bianca.guettner@nct-dresden.de.
-
-
 """
 biolgca is a Python package for simulating different types of lattice-gas
 cellular automata (LGCA) in the biological context. It is under active development.

--- a/lgca/base.py
+++ b/lgca/base.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2024 Technische Universität Dresden, contact: simon.syga@tu-dresden.de.
+# Copyright (C) 2018-2025 Technische Universität Dresden, contact: simon.syga@tu-dresden.de.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Abstract base classes. These classes define properties and structure of the LGCA
 types/subclasses and specify geometry-independent LGCA behavior.

--- a/lgca/base_extensions.py
+++ b/lgca/base_extensions.py
@@ -1,3 +1,14 @@
+# biolgca is a Python package for simulating different kinds of lattice-gas
+# cellular automata (LGCA) in the biological context.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
+# The full license notice is found in the file lgca/__init__.py.
+"""Extensions to the base LGCA classes.
+
+Provides abstract classes for identity-based models with or without
+volume exclusion.
+"""
+
+
 from __future__ import annotations
 
 import warnings

--- a/lgca/cubic_ext.py
+++ b/lgca/cubic_ext.py
@@ -1,3 +1,13 @@
+# biolgca is a Python package for simulating different kinds of lattice-gas
+# cellular automata (LGCA) in the biological context.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
+# The full license notice is found in the file lgca/__init__.py.
+"""Extended 3D cubic LGCA models.
+
+Adds identity-based and no-volume-exclusion variants for cubic geometries.
+"""
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/lgca/ib_interactions.py
+++ b/lgca/ib_interactions.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Interaction functions and helper functions for identity-based LGCA with volume exclusion.
 """

--- a/lgca/interactions.py
+++ b/lgca/interactions.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Interaction functions and helper functions for classical LGCA with volume exclusion.
 """

--- a/lgca/lgca_1d.py
+++ b/lgca/lgca_1d.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Classes for one-dimensional LGCA. They specify geometry-dependent LGCA behavior
 and inherit properties and structure from the respective abstract base classes.

--- a/lgca/lgca_3dmoore.py
+++ b/lgca/lgca_3dmoore.py
@@ -1,3 +1,7 @@
+# biolgca is a Python package for simulating different kinds of lattice-gas
+# cellular automata (LGCA) in the biological context.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
+# The full license notice is found in the file lgca/__init__.py.
 """3D Moore lattice LGCA implementations."""
 
 import numpy as np

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -1,3 +1,11 @@
+# biolgca is a Python package for simulating different kinds of lattice-gas
+# cellular automata (LGCA) in the biological context.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
+# The full license notice is found in the file lgca/__init__.py.
+"""3D cubic lattice LGCA implementations.
+"""
+
+
 from lgca.base import *
 try:  # optional plotting dependency
     from mayavi import mlab

--- a/lgca/lgca_hex.py
+++ b/lgca/lgca_hex.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Classes for two-dimensional LGCA on a hexagonal arm-share lattice. They specify
 geometry-dependent LGCA behavior and inherit properties and structure from the

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Classes for two-dimensional LGCA on a square lattice. They specify
 geometry-dependent LGCA behavior and inherit properties and structure from the

--- a/lgca/nove_ib_interactions.py
+++ b/lgca/nove_ib_interactions.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Interaction functions and helper functions for identity-based LGCA without volume exclusion.
 """

--- a/lgca/nove_interactions.py
+++ b/lgca/nove_interactions.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """
 Interaction functions and helper functions for LGCA without volume exclusion.
 """

--- a/lgca/plots.py
+++ b/lgca/plots.py
@@ -1,8 +1,7 @@
 # biolgca is a Python package for simulating different kinds of lattice-gas
 # cellular automata (LGCA) in the biological context.
-# Copyright (C) 2018-2022 Technische Universität Dresden, Germany.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
 # The full license notice is found in the file lgca/__init__.py.
-
 """Utilities for plotting properties and outputs of all LGCA types."""
 
 import numpy as np

--- a/lgca/square_ext.py
+++ b/lgca/square_ext.py
@@ -1,3 +1,13 @@
+# biolgca is a Python package for simulating different kinds of lattice-gas
+# cellular automata (LGCA) in the biological context.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
+# The full license notice is found in the file lgca/__init__.py.
+"""Extended 2D square LGCA models.
+
+Includes identity-based and no-volume-exclusion simulators.
+"""
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/lgca/square_plotting.py
+++ b/lgca/square_plotting.py
@@ -1,3 +1,13 @@
+# biolgca is a Python package for simulating different kinds of lattice-gas
+# cellular automata (LGCA) in the biological context.
+# Copyright (C) 2018-2025 Technische Universität Dresden, Germany.
+# The full license notice is found in the file lgca/__init__.py.
+"""Plotting utilities for square lattice LGCA.
+
+Provides helper functions for visualizing square LGCA simulations.
+"""
+
+
 import numpy as np
 import warnings
 


### PR DESCRIPTION
## Summary
- update BSD license headers to reference 2018-2025
- ensure module docstrings come right after headers

## Testing Done
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bd249464483338868ffd814b8c7f3