### PR TITLE
Feat refactor permutation getters

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -856,9 +856,22 @@ class LGCA_base(ABC):
                        range(self.K + 1)]
 
     def get_permutations(self, n_particles):
-        """Get permutations for n_particles, computing if necessary."""
-        if self.permutations is not None:
+        """Get permutations for ``n_particles``.
+
+        Parameters
+        ----------
+        n_particles : int
+            Number of occupied channels.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of permutations for ``n_particles``.
+        """
+        try:
             return self.permutations[n_particles]
+        except (AttributeError, TypeError):
+            pass
 
         if n_particles not in self._permutation_cache:
             # Limit cache size to prevent memory issues
@@ -874,9 +887,11 @@ class LGCA_base(ABC):
         return self._permutation_cache[n_particles]
 
     def get_flux_permutations(self, n_particles):
-        """Get flux permutations for n_particles, computing if necessary."""
-        if hasattr(self, 'j') and self.j is not None:
+        """Get flux permutations for ``n_particles``."""
+        try:
             return self.j[n_particles]
+        except (AttributeError, TypeError):
+            pass
 
         if n_particles not in self._flux_cache:
             perms = self.get_permutations(n_particles)


### PR DESCRIPTION
## Summary
- use try/except when returning cached permutations
- update flux permutation retrieval

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684bd69f89988333a561203a98bcf900