### PR TITLE
[Fix] handle persistent motion alias

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -434,7 +434,7 @@ class LGCA_base(ABC):
                 contact_guidance, nematic, aggregation, wetting, random_walk, birthdeath, excitable_medium, \
                 only_propagation
         if 'interaction' in kwargs:
-            interaction = kwargs['interaction']
+            interaction = kwargs['interaction'].replace(" ", "_")
             if interaction == 'go_or_grow':
                 self.interaction = go_or_grow
                 if 'r_d' in kwargs:

--- a/tests/test_get_lgca.py
+++ b/tests/test_get_lgca.py
@@ -112,3 +112,12 @@ def test_warning_on_nonboolean_nodes():
         )
     assert set(np.unique(lgca.nodes[lgca.nonborder])) <= {0, 1}
 
+
+def test_persistent_motion_space_alias():
+    lgca = get_lgca(
+        geometry="square",
+        dims=3,
+        interaction="persistent motion",
+    )
+    assert lgca.interaction.__name__ == "persistent_walk"
+


### PR DESCRIPTION
## Summary
- allow specifying `persistent motion` (with space) as alias for the persistent motion interaction
- test that the alias works

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d65b0d5ac8333809b9db9b9236b75