### PR TITLE
[Fix] update imports after LGCA refactor

### DIFF
--- a/lgca/__init__.py
+++ b/lgca/__init__.py
@@ -216,11 +216,11 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
         if geom_key == 'lin':
             from lgca.lgca_1d import NoVE_LGCA_1D as _Cls
         elif geom_key == 'square':
-            from lgca.lgca_square import NoVE_LGCA_Square as _Cls
+            from lgca.square_ext import NoVE_LGCA_Square as _Cls
         elif geom_key == 'hex':
             from lgca.lgca_hex import NoVE_LGCA_Hex as _Cls
         elif geom_key == 'cubic':
-            from lgca.lgca_cubic import NoVE_LGCA_Cubic as _Cls
+            from lgca.cubic_ext import NoVE_LGCA_Cubic as _Cls
         elif geom_key == 'moore':
             from lgca.lgca_3dmoore import NoVE_LGCA_Moore as _Cls
         else:
@@ -232,11 +232,11 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
         if geom_key == 'lin':
             from lgca.lgca_1d import IBLGCA_1D as _Cls
         elif geom_key == 'square':
-            from lgca.lgca_square import IBLGCA_Square as _Cls
+            from lgca.square_ext import IBLGCA_Square as _Cls
         elif geom_key == 'hex':
             from lgca.lgca_hex import IBLGCA_Hex as _Cls
         elif geom_key == 'cubic':
-            from lgca.lgca_cubic import IBLGCA_Cubic as _Cls
+            from lgca.cubic_ext import IBLGCA_Cubic as _Cls
         elif geom_key == 'moore':
             from lgca.lgca_3dmoore import IBLGCA_Moore as _Cls
         else:
@@ -248,11 +248,11 @@ def get_lgca(geometry: str = 'hex', ib: bool = False, ve: bool = True, **kwargs)
         if geom_key == 'lin':
             from lgca.lgca_1d import NoVE_IBLGCA_1D as _Cls
         elif geom_key == 'square':
-            from lgca.lgca_square import NoVE_IBLGCA_Square as _Cls
+            from lgca.square_ext import NoVE_IBLGCA_Square as _Cls
         elif geom_key == 'hex':
             from lgca.lgca_hex import NoVE_IBLGCA_Hex as _Cls
         elif geom_key == 'cubic':
-            from lgca.lgca_cubic import NoVE_IBLGCA_Cubic as _Cls
+            from lgca.cubic_ext import NoVE_IBLGCA_Cubic as _Cls
         elif geom_key == 'moore':
             from lgca.lgca_3dmoore import NoVE_IBLGCA_Moore as _Cls
         else:

--- a/lgca/lgca_3dmoore.py
+++ b/lgca/lgca_3dmoore.py
@@ -5,8 +5,8 @@
 """3D Moore lattice LGCA implementations."""
 
 import numpy as np
-from lgca.lgca_cubic import (
-    LGCA_Cubic,
+from lgca.lgca_cubic import LGCA_Cubic
+from lgca.cubic_ext import (
     IBLGCA_Cubic,
     NoVE_LGCA_Cubic,
     NoVE_IBLGCA_Cubic,

--- a/tests/test_get_lgca.py
+++ b/tests/test_get_lgca.py
@@ -3,10 +3,11 @@ import numpy as np
 
 from lgca import get_lgca
 from lgca.lgca_1d import LGCA_1D, IBLGCA_1D, NoVE_LGCA_1D, NoVE_IBLGCA_1D
-from lgca.lgca_square import LGCA_Square, IBLGCA_Square, NoVE_LGCA_Square, NoVE_IBLGCA_Square
+from lgca.lgca_square import LGCA_Square
+from lgca.square_ext import IBLGCA_Square, NoVE_LGCA_Square, NoVE_IBLGCA_Square
 from lgca.lgca_hex import LGCA_Hex, IBLGCA_Hex, NoVE_LGCA_Hex, NoVE_IBLGCA_Hex
-from lgca.lgca_cubic import (
-    LGCA_Cubic,
+from lgca.lgca_cubic import LGCA_Cubic
+from lgca.cubic_ext import (
     IBLGCA_Cubic,
     NoVE_LGCA_Cubic,
     NoVE_IBLGCA_Cubic,


### PR DESCRIPTION
## Summary
- update `get_lgca` to use moved classes from `square_ext` and `cubic_ext`
- fix `lgca_3dmoore` imports
- adjust tests to import the new modules

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68500c53a6e0833399018f12f6bc2cce