### PR TITLE
Feat vectorize nove interactions

### DIFF
--- a/lgca/nove_interactions.py
+++ b/lgca/nove_interactions.py
@@ -27,21 +27,10 @@ def random_walk(lgca):
     No other attributes are updated.
     """
     newnodes = lgca.nodes.copy()
-    # filter for nodes that are not virtual border lattice sites
-    relevant = (lgca.cell_density[lgca.nonborder] > 0)
-    coords = [a[relevant] for a in lgca.nonborder]
+    weights = np.full(lgca.K, 1 / lgca.K)
 
-    weights = np.ones(lgca.K)
-    weights /= lgca.K
-
-    # loop through lattice sites and reassign particle directions
-    for coord in zip(*coords):
-        # number of particles
-        n = lgca.cell_density[coord]
-        # reassign particle directions
-        sample = lgca.rng.multinomial(n, weights,)
-
-        newnodes[coord] = sample
+    nb_nodes = lgca.cell_density[lgca.nonborder]
+    newnodes[lgca.nonborder] = lgca.rng.multinomial(nb_nodes, weights)
 
     lgca.nodes = newnodes
 
@@ -66,39 +55,19 @@ def dd_alignment(lgca):
     -----
     ``lgca.nodes`` is replaced by the sampled configuration.
     """
-    newnodes = lgca.nodes.copy()
-    # filter for nodes that are not virtual border lattice sites
-    relevant = (lgca.cell_density[lgca.nonborder] > 0)
-    coords = [a[relevant] for a in lgca.nonborder]
-    # calculate director field
-    g = lgca.calc_flux(lgca.nodes)  # flux for each lattice site
+    beta = lgca.interaction_params['beta']
+    g = lgca.calc_flux(lgca.nodes)
     if lgca.interaction_params['nb_include_center']:
         g += lgca.nb_sum(g)
     else:
         g = lgca.nb_sum(g)
-    # sum of flux of neighbors for each lattice site
 
+    weights = np.exp(beta * np.einsum('...i,ij->...j', g, lgca.c))
+    weights /= weights.sum(axis=-1, keepdims=True)
 
-    # loop through lattice sites and reassign particle directions
-    for coord in zip(*coords):
-        # number of particles
-        n = lgca.cell_density[coord]
-        # calculate transition probabilities for directions
-        weights = np.exp(lgca.interaction_params['beta'] * np.einsum('i,ij', g[coord], lgca.c))
-
-        z = weights.sum()
-        # to prevent divisions by zero if the weight is zero
-        aux = np.nan_to_num(z)
-        weights = np.nan_to_num(weights)
-        weights = (weights / aux)
-        # In case there are some rounding problems
-        if weights.sum() > 1:
-            weights = (weights / weights.sum())
-
-        # reassign particle directions
-        sample = lgca.rng.multinomial(n, weights,)
-
-        newnodes[coord] = sample
+    newnodes = lgca.nodes.copy()
+    nb_density = lgca.cell_density[lgca.nonborder]
+    newnodes[lgca.nonborder] = lgca.rng.multinomial(nb_density, weights[lgca.nonborder])
 
     lgca.nodes = newnodes
 
@@ -123,42 +92,24 @@ def di_alignment(lgca):
     -----
     ``lgca.nodes`` is replaced by the sampled configuration.
     """
-    newnodes = lgca.nodes.copy()
-    # filter for nodes that are not virtual border lattice sites
-    relevant = (lgca.cell_density[lgca.nonborder] > 0)
-    coords = [a[relevant] for a in lgca.nonborder]
-    # calculate director field
-    g = lgca.calc_flux(lgca.nodes)  # flux for each lattice site
+    beta = lgca.interaction_params['beta']
+    g = lgca.calc_flux(lgca.nodes)
     if lgca.interaction_params['nb_include_center']:
         g += lgca.nb_sum(g)
-        nsum = lgca.nb_sum(lgca.cell_density)[..., None] + lgca.cell_density[..., None]     # normalize director field by number of neighbors
-
+        nsum = lgca.nb_sum(lgca.cell_density)[..., None] + lgca.cell_density[..., None]
     else:
         g = lgca.nb_sum(g)
         nsum = lgca.nb_sum(lgca.cell_density)[..., None]
 
-    np.maximum(nsum, 1, out=nsum)   # avoid dividing by zero later
+    np.maximum(nsum, 1, out=nsum)
     g = g / nsum
 
-    # loop through lattice sites and reassign particle directions
-    for coord in zip(*coords):
-        # number of particles
-        n = lgca.cell_density[coord]
-        # calculate transition probabilities for directions
-        weights = np.exp(lgca.interaction_params['beta'] * np.einsum('i,ij', g[coord], lgca.c))
-        z = weights.sum()
-        # avoid division by zero if weights is zero
-        aux = np.nan_to_num(z)
-        weights = np.nan_to_num(weights)
-        weights = (weights / aux)
-        # In case there are rounding problems
-        if weights.sum() > 1:
-            weights = (weights / weights.sum())
+    weights = np.exp(beta * np.einsum('...i,ij->...j', g, lgca.c))
+    weights /= weights.sum(axis=-1, keepdims=True)
 
-        # reassign particle directions
-        sample = lgca.rng.multinomial(n, weights, )
-
-        newnodes[coord] = sample
+    newnodes = lgca.nodes.copy()
+    nb_density = lgca.cell_density[lgca.nonborder]
+    newnodes[lgca.nonborder] = lgca.rng.multinomial(nb_density, weights[lgca.nonborder])
 
     lgca.nodes = newnodes
 
@@ -182,40 +133,27 @@ def go_or_grow(lgca):
     -----
     ``lgca.nodes`` is overwritten with the updated node configuration.
     """
-    relevant = lgca.cell_density[lgca.nonborder] > 0
-    coords = [a[relevant] for a in lgca.nonborder]
-    n_m = lgca.nodes[..., :lgca.velocitychannels].sum(-1)
-    n_r = lgca.nodes[..., lgca.velocitychannels:].sum(-1)
+    nb_nodes = lgca.nodes[lgca.nonborder]
+    n_m = nb_nodes[..., :lgca.velocitychannels].sum(-1)
+    n_r = nb_nodes[..., lgca.velocitychannels:].sum(-1)
+    rho = (n_m + n_r) / lgca.capacity
 
-    for coord in zip(*coords):
-        # determine cell number and moving and resting cell population at coordinate
-        n = lgca.cell_density[coord]
-        n_mxy = n_m[coord]
-        n_rxy = n_r[coord]
-        rho = n / lgca.capacity
+    prob = tanh_switch(rho, kappa=lgca.interaction_params['kappa'], theta=lgca.interaction_params['theta'])
+    j_1 = lgca.rng.binomial(n_m, prob)
+    j_2 = lgca.rng.binomial(n_r, 1 - prob)
+    n_m = n_m + j_2 - j_1
+    n_r = n_r + j_1 - j_2
 
-        # phenotypic switch
-        j_1 = lgca.rng.binomial(n_mxy, tanh_switch(rho, kappa=lgca.interaction_params['kappa'],
-                                              theta=lgca.interaction_params['theta']))
-        j_2 = lgca.rng.binomial(n_rxy, 1 - tanh_switch(rho, kappa=lgca.interaction_params['kappa'],
-                                                  theta=lgca.interaction_params['theta']))
-        n_mxy += j_2 - j_1
-        n_rxy += j_1 - j_2
+    n_m -= lgca.rng.binomial(n_m, lgca.interaction_params['r_d'])
+    n_r -= lgca.rng.binomial(n_r, lgca.interaction_params['r_d'])
+    birth_prob = np.clip(lgca.interaction_params['r_b'] * (1 - rho), 0, 1)
+    n_r += lgca.rng.binomial(n_r, birth_prob)
 
-        # death
-        n_mxy -= lgca.rng.binomial(n_mxy * np.heaviside(n_mxy, 0), lgca.interaction_params['r_d'])
-        n_rxy -= lgca.rng.binomial(n_rxy * np.heaviside(n_rxy, 0), lgca.interaction_params['r_d'])
-
-        # birth
-        n_rxy += lgca.rng.binomial(n_rxy * np.heaviside(n_rxy, 0), np.maximum(lgca.interaction_params['r_b']*(1-rho), 0))
-
-        # reorientation
-        v_channels = lgca.rng.multinomial(n_mxy, [1/lgca.velocitychannels]*lgca.velocitychannels)
-
-        # add resting cells and assign new content of node at the end of interaction step
-        r_channels = np.array([n_rxy])
-        node = np.hstack((v_channels, r_channels))
-        lgca.nodes[coord] = node
+    weights = np.full(lgca.velocitychannels, 1 / lgca.velocitychannels)
+    v_channels = lgca.rng.multinomial(n_m, weights)
+    r_channels = n_r[..., None]
+    nb_new = np.concatenate((v_channels, r_channels), axis=-1)
+    lgca.nodes[lgca.nonborder] = nb_new.astype(lgca.nodes.dtype)
 
 
 def go_or_rest(lgca):
@@ -235,30 +173,19 @@ def go_or_rest(lgca):
     -----
     ``lgca.nodes`` is overwritten with the updated node configuration.
     """
-    relevant = lgca.cell_density[lgca.nonborder] > 0
-    coords = [a[relevant] for a in lgca.nonborder]
-    n_m = lgca.nodes[..., :lgca.velocitychannels].sum(-1)
-    n_r = lgca.nodes[..., lgca.velocitychannels:].sum(-1)
+    nb_nodes = lgca.nodes[lgca.nonborder]
+    n_m = nb_nodes[..., :lgca.velocitychannels].sum(-1)
+    n_r = nb_nodes[..., lgca.velocitychannels:].sum(-1)
+    rho = (n_m + n_r) / lgca.capacity
 
-    for coord in zip(*coords):
-        # determine cell number and moving and resting cell population at coordinate
-        n = lgca.cell_density[coord]
-        n_mxy = n_m[coord]
-        n_rxy = n_r[coord]
-        rho = n / lgca.capacity
+    prob = tanh_switch(rho, kappa=lgca.interaction_params['kappa'], theta=lgca.interaction_params['theta'])
+    j_1 = lgca.rng.binomial(n_m, prob)
+    j_2 = lgca.rng.binomial(n_r, 1 - prob)
+    n_m = n_m + j_2 - j_1
+    n_r = n_r + j_1 - j_2
 
-        # phenotypic switch
-        j_1 = lgca.rng.binomial(n_mxy, tanh_switch(rho, kappa=lgca.interaction_params['kappa'],
-                                              theta=lgca.interaction_params['theta']))
-        j_2 = lgca.rng.binomial(n_rxy, 1 - tanh_switch(rho, kappa=lgca.interaction_params['kappa'],
-                                                  theta=lgca.interaction_params['theta']))
-        n_mxy += j_2 - j_1
-        n_rxy += j_1 - j_2
-
-        # reorientation
-        v_channels = lgca.rng.multinomial(n_mxy, [1/lgca.velocitychannels]*lgca.velocitychannels)
-
-        # add resting cells and assign new content of node at the end of interaction step
-        r_channels = np.array([n_rxy])
-        node = np.hstack((v_channels, r_channels))
-        lgca.nodes[coord] = node
+    weights = np.full(lgca.velocitychannels, 1 / lgca.velocitychannels)
+    v_channels = lgca.rng.multinomial(n_m, weights)
+    r_channels = n_r[..., None]
+    nb_new = np.concatenate((v_channels, r_channels), axis=-1)
+    lgca.nodes[lgca.nonborder] = nb_new.astype(lgca.nodes.dtype)


### PR DESCRIPTION
## Summary
- vectorize `random_walk`, `dd_alignment`, `di_alignment`, `go_or_grow` and `go_or_rest`

## Testing Done
- `pytest -q` *(fails: Killed)*

------
https://chatgpt.com/codex/tasks/task_e_68500fb9e8a083339a5f2bfa27f674d0