### PR TITLE
Feat density per node

### DIFF
--- a/BioLGCA.ipynb
+++ b/BioLGCA.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "source": [
     "### Setting the initial state\n",
-    "By default, the initial state is a homogeneous state with constant mean density, that can be set using the `density` keyword. For `density = 0.1` every channel on the lattice is occupied with a probability of $0.1$. The state of the lgca class instance is saved in the array `nodes`. For example, for a 1D LGCA of size 5, without rest channels and with a homogeneous initial state, where each channel is occupied with a probability $\\rho = 0.1$, we use"
+    "By default, the initial state is a homogeneous state with constant mean density, that can be set using the `density` keyword. For `density = 0.1` each node contains on average $0.1$ particles, independent of the lattice geometry. The state of the lgca class instance is saved in the array `nodes`. For example, for a 1D LGCA of size 5, without rest channels and with a homogeneous initial state of mean density $\\rho = 0.1$, we use"
    ]
   },
   {

--- a/lgca/base.py
+++ b/lgca/base.py
@@ -763,25 +763,21 @@ class LGCA_base(ABC):
         print(self.nodes.astype(int))
 
     def random_reset(self, density):
-        """
-        Initialize lattice nodes with average density `density`. Channels are occupied at random and nodes can
-        have different particle numbers.
+        """Randomly fill channels so that each node has on average ``density`` particles.
 
-        For each channel a random number is drawn. If it is lower than `density`, the channel is filled,
-        otherwise it stays empty.
+        Each channel is independently occupied with probability ``density / self.K``.
 
         Parameters
         ----------
         density : float
-            Desired average particle density of the lattice.
-            ``density = total_number_of_particles / (number_of_nodes * number_of_channels_per_node)``.
-
+            Desired average number of particles per node.
+            ``density = total_number_of_particles / number_of_nodes``.
         """
-        self.nodes = npr.random(self.nodes.shape) < density
+        self.nodes = npr.random(self.nodes.shape) < (density / self.K)
         self.apply_boundaries()
         self.update_dynamic_fields()
-        # achieved density
-        # eff_dens = self.nodes[self.nonborder].sum() / (self.K * self.cell_density[self.nonborder].size)
+        # achieved density example
+        # eff_dens = self.nodes[self.nonborder].sum() / self.cell_density[self.nonborder].size
 
     def update_dynamic_fields(self):
         """

--- a/lgca/base_extensions.py
+++ b/lgca/base_extensions.py
@@ -398,21 +398,17 @@ class IBLGCA_base(LGCA_base, ABC):
         return conf
 
     def random_reset(self, density):
-        """
-        Initialize lattice nodes with average density `density`. Channels are occupied at random and nodes can
-        have different particle numbers.
+        """Randomly fill channels so that each node has on average ``density`` particles.
 
-        For each channel a random number is drawn. If it is lower than `density`, the channel is filled,
-        otherwise it stays empty.
+        Each channel is independently occupied with probability ``density / self.K``.
 
         Parameters
         ----------
         density : float
-            Desired average particle density of the lattice.
-            ``density = total_number_of_particles / (number_of_nodes * number_of_channels_per_node)``.
-
+            Desired average number of particles per node.
+            ``density = total_number_of_particles / number_of_nodes``.
         """
-        occupied = npr.random(self.dims + (self.K,)) < density
+        occupied = npr.random(self.dims + (self.K,)) < (density / self.K)
         self.nodes[self.nonborder] = self.convert_bool_to_ib(occupied)
         self.apply_boundaries()
 
@@ -1530,23 +1526,18 @@ class NoVE_LGCA_base(LGCA_base, ABC):
                 self.restcells_t[t, ...] = self.nodes[self.nonborder][..., self.velocitychannels:].sum(-1)
 
     def random_reset(self, density):
-        """
-        Distribute particles in the lattice according to a given density; can yield different cell numbers per
-        lattice site
-        :param density: particle density in the lattice: average number of particles per channel
-        """
+        """Populate the lattice from a Poisson distribution with mean ``density`` per node."""
 
-        # sample from a Poisson distribution with mean=density
-        density = abs(density)
+        density = abs(density) / self.capacity
         draw1 = npr.poisson(lam=density, size=self.nodes.shape)
         if self.capacity > self.K:
-            draw2 = npr.poisson(lam=density, size=self.nodes.shape[:-1]+((self.capacity-self.K),))
+            draw2 = npr.poisson(lam=density, size=self.nodes.shape[:-1] + ((self.capacity - self.K),))
             draw1[..., -1] += draw2.sum(-1)
         self.nodes = draw1
         self.apply_boundaries()
         self.update_dynamic_fields()
-        eff_dens = self.nodes[self.nonborder].sum()/(self.capacity * self.cell_density[self.nonborder].size)
-        print("Required density: {:.3f}, Achieved density: {:.3f}".format(density, eff_dens))
+        eff_dens = self.nodes[self.nonborder].sum() / self.cell_density[self.nonborder].size
+        print("Required density: {:.3f}, Achieved density: {:.3f}".format(density * self.capacity, eff_dens))
 
 
     def calc_entropy(self, base=None):
@@ -1713,14 +1704,12 @@ class NoVE_IBLGCA_base(NoVE_LGCA_base, IBLGCA_base, ABC):
         return tempnodes
 
     def random_reset(self, density):
-        """
-        Distribute particles in the lattice according to a given density; can yield different cell numbers per lattice site
-        :param density: particle density in the lattice: average number of particles per channel
-        """
-        density = npr.poisson(lam=density, size=self.dims + (self.K,))
-        tempnodes = self.convert_int_to_ib(density)
+        """Populate the lattice from a Poisson distribution with mean ``density`` per node."""
+        lam = abs(density) / self.capacity
+        numbers = npr.poisson(lam=lam, size=self.dims + (self.K,))
+        tempnodes = self.convert_int_to_ib(numbers)
         self.nodes[self.nonborder] = tempnodes
-        self.maxlabel = density.sum()
+        self.maxlabel = numbers.sum()
         self.update_dynamic_fields()
 
     def set_interaction(self, **kwargs):

--- a/lgca/lgca_1d.py
+++ b/lgca/lgca_1d.py
@@ -107,14 +107,14 @@ class LGCA_1D(LGCA_base):
         Initialize LGCA lattice configuration. Create the lattice and then assign particles to
         channels in the nodes.
 
-        Initializes :py:attr:`self.nodes`. If `nodes` is not provided, the lattice is initialized with particles
-        randomly so that the averge lattice density is `density`. For the random initialization there is a choice
-        between a fixed or random number of particles per node.
+        Initializes :py:attr:`self.nodes`. If `nodes` is not provided, the lattice is initialized randomly so that
+        each node contains on average ``density`` particles. For the random initialization there is a choice between
+        a fixed or random number of particles per node.
 
         Parameters
         ----------
         density : float, default=0.1
-            If `nodes` is None, initialize lattice randomly with this particle density.
+            If `nodes` is None, initialize lattice randomly with this average number of particles per node.
         nodes : :py:class:`numpy.ndarray`
             Custom initial lattice configuration. Dimensions: ``(self.dims[0], self.K)``.
 

--- a/lgca/lgca_cubic.py
+++ b/lgca/lgca_cubic.py
@@ -111,13 +111,13 @@ class LGCA_Cubic(LGCA_base):
         """
         Initialize LGCA lattice configuration. Create the lattice and then assign particles to channels in the nodes.
 
-        Initializes :py:attr:`self.nodes`. If `nodes` is not provided, the lattice is initialized with particles
-        randomly so that the average lattice density is `density`.
+        Initializes :py:attr:`self.nodes`. If `nodes` is not provided, the lattice is initialized randomly so that
+        each node contains on average ``density`` particles.
 
         Parameters
         ----------
         density : float, default=0.1
-            If `nodes` is None, initialize lattice randomly with this particle density.
+            If `nodes` is None, initialize lattice randomly with this average number of particles per node.
         nodes : :py:class:`numpy.ndarray`
             Custom initial lattice configuration. Dimensions: ``(self.lx, self.ly, self.lz, self.K)``.
 

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -138,14 +138,14 @@ class LGCA_Square(SquarePlotMixin, LGCA_base):
         Initialize LGCA lattice configuration. Create the lattice and then assign particles to
         channels in the nodes.
 
-        Initializes :py:attr:`self.nodes`. If `nodes` is not provided, the lattice is initialized with particles
-        randomly so that the averge lattice density is `density`. For the random initialization there is a choice
-        between a fixed or random number of particles per node.
+        Initializes :py:attr:`self.nodes`. If `nodes` is not provided, the lattice is initialized randomly so that
+        each node contains on average ``density`` particles. For the random initialization there is a choice between
+        a fixed or random number of particles per node.
 
         Parameters
         ----------
         density : float, default=0.1
-            If `nodes` is None, initialize lattice randomly with this particle density.
+            If `nodes` is None, initialize lattice randomly with this average number of particles per node.
         nodes : :py:class:`numpy.ndarray`
             Custom initial lattice configuration. Dimensions: ``(self.dims[0], self.dims[1], self.K)``.
 

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -336,7 +336,7 @@ class Test_LGCA_General:
                 "Node configuration is not random"
             assert lgca.nodes[lgca.nonborder].sum(-1).min() != lgca.nodes[lgca.nonborder].sum(-1).max(), \
                 "Number of particles is homogeneous when it should differ randomly"
-        assert np.abs(lgca.nodes[lgca.nonborder].sum() / (capacity * lgca.cell_density[lgca.nonborder].size) - density) \
+        assert np.abs(lgca.nodes[lgca.nonborder].sum() / lgca.cell_density[lgca.nonborder].size - density) \
                < self.com.density_epsilon, "Wrong density reached"
         if ve and not ib:
             assert np.max(lgca.nodes.astype(int)) <= 1, "Volume exclusion principle is not respected"


### PR DESCRIPTION
## Summary
- redefine density as particles per node
- random reset functions now use `density/self.K`
- update Poisson initialisation for NoVE variants
- document new meaning in class docstrings and tutorial
- adjust density checks in tests

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850421cdbf483338d636a74b1b02437