### PR TITLE
[Fix] route all random operations through Generator

### DIFF
--- a/lgca/base.py
+++ b/lgca/base.py
@@ -773,7 +773,7 @@ class LGCA_base(ABC):
             Desired average number of particles per node.
             ``density = total_number_of_particles / number_of_nodes``.
         """
-        self.nodes = npr.random(self.nodes.shape) < (density / self.K)
+        self.nodes = self.rng.random(self.nodes.shape) < (density / self.K)
         self.apply_boundaries()
         self.update_dynamic_fields()
         # achieved density example

--- a/lgca/base_extensions.py
+++ b/lgca/base_extensions.py
@@ -408,7 +408,7 @@ class IBLGCA_base(LGCA_base, ABC):
             Desired average number of particles per node.
             ``density = total_number_of_particles / number_of_nodes``.
         """
-        occupied = npr.random(self.dims + (self.K,)) < (density / self.K)
+        occupied = self.rng.random(self.dims + (self.K,)) < (density / self.K)
         self.nodes[self.nonborder] = self.convert_bool_to_ib(occupied)
         self.apply_boundaries()
 
@@ -1529,9 +1529,9 @@ class NoVE_LGCA_base(LGCA_base, ABC):
         """Populate the lattice from a Poisson distribution with mean ``density`` per node."""
 
         density = abs(density) / self.capacity
-        draw1 = npr.poisson(lam=density, size=self.nodes.shape)
+        draw1 = self.rng.poisson(lam=density, size=self.nodes.shape)
         if self.capacity > self.K:
-            draw2 = npr.poisson(lam=density, size=self.nodes.shape[:-1] + ((self.capacity - self.K),))
+            draw2 = self.rng.poisson(lam=density, size=self.nodes.shape[:-1] + ((self.capacity - self.K),))
             draw1[..., -1] += draw2.sum(-1)
         self.nodes = draw1
         self.apply_boundaries()
@@ -1706,7 +1706,7 @@ class NoVE_IBLGCA_base(NoVE_LGCA_base, IBLGCA_base, ABC):
     def random_reset(self, density):
         """Populate the lattice from a Poisson distribution with mean ``density`` per node."""
         lam = abs(density) / self.capacity
-        numbers = npr.poisson(lam=lam, size=self.dims + (self.K,))
+        numbers = self.rng.poisson(lam=lam, size=self.dims + (self.K,))
         tempnodes = self.convert_int_to_ib(numbers)
         self.nodes[self.nonborder] = tempnodes
         self.maxlabel = numbers.sum()

--- a/lgca/ib_interactions.py
+++ b/lgca/ib_interactions.py
@@ -81,11 +81,11 @@ def birth(lgca):
 
         # choose cells that proliferate
         r_bs = np.array([lgca.props['r_b'][i] for i in node])
-        proliferating = npr.random(lgca.K) < r_bs
+        proliferating = lgca.rng.random(lgca.K) < r_bs
 
         # pick a random channel for each proliferating cell. If it is empty, place the daughter cell there
         for label in node[proliferating]:
-            ind = npr.choice(lgca.K)
+            ind = lgca.rng.choice(lgca.K)
             if node[ind] == 0:
                 lgca.maxlabel += 1
                 node[ind] = lgca.maxlabel
@@ -116,7 +116,7 @@ def birthdeath(lgca):
     ``lgca`` and its property lists are altered in place.
     """
     # death process, remember who will die but give them the chance to proliferate
-    dying = (npr.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
+    dying = (lgca.rng.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
 
     # birth
     relevant = (lgca.cell_density[lgca.nonborder] > 0) & \
@@ -128,11 +128,11 @@ def birthdeath(lgca):
 
         # choose cells that proliferate
         r_bs = np.array([lgca.props['r_b'][i] for i in node])
-        proliferating = (npr.random(lgca.K) * occ) < r_bs
+        proliferating = (lgca.rng.random(lgca.K) * occ) < r_bs
         n_p = proliferating.sum()
         if n_p == 0:
             continue
-        targetchannels = npr.choice(lgca.K, size=n_p, replace=False)
+        targetchannels = lgca.rng.choice(lgca.K, size=n_p, replace=False)
         # pick a random channel for each proliferating cell. If it is empty, place the daughter cell there
         for i, label in enumerate(node[proliferating]):
             ind = targetchannels[i]
@@ -171,7 +171,7 @@ def birthdeath_discrete(lgca):
     Operates in place on ``lgca``.
     """
     # determine which cells will die
-    dying = (npr.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
+    dying = (lgca.rng.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
     lgca.nodes[dying] = 0
     lgca.update_dynamic_fields()
     relevant = (lgca.cell_density[lgca.nonborder] > 0)
@@ -183,12 +183,12 @@ def birthdeath_discrete(lgca):
         # choose cells that proliferate
 
         r_bs = np.array([lgca.props['r_b'][i] for i in node])
-        proliferating = (npr.random(lgca.K) * occ) < r_bs
+        proliferating = (lgca.rng.random(lgca.K) * occ) < r_bs
         n_p = proliferating.sum()
         if n_p == 0:
             continue
         # pick a random channel for each proliferating cell. If it is empty, place the daughter cell there
-        targetchannels = npr.choice(lgca.K, size=n_p, replace=False)
+        targetchannels = lgca.rng.choice(lgca.K, size=n_p, replace=False)
 
         for i, label in enumerate(node[proliferating]):
             ind = targetchannels[i]
@@ -231,7 +231,7 @@ def go_or_grow(lgca):
     """
 
     # death
-    dying = (npr.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
+    dying = (lgca.rng.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
     lgca.nodes[dying] = 0
 
     # birth
@@ -255,40 +255,40 @@ def go_or_grow(lgca):
         free_rest = lgca.restchannels - n_r[coord]
         free_vel = lgca.velocitychannels - n_m[coord]
         # choose a number of cells that try to switch. the cell number must fit to the number of free channels
-        can_switch_to_rest = npr.permutation(vel[vel > 0])[:free_rest]
-        can_switch_to_vel = npr.permutation(rest[rest > 0])[:free_vel]
+        can_switch_to_rest = lgca.rng.permutation(vel[vel > 0])[:free_rest]
+        can_switch_to_vel = lgca.rng.permutation(rest[rest > 0])[:free_vel]
 
         for cell in can_switch_to_rest:
-            if npr.random() < tanh_switch(rho, kappa=lgca.props['kappa'][cell], theta=lgca.props['theta'][cell]):
+            if lgca.rng.random() < tanh_switch(rho, kappa=lgca.props['kappa'][cell], theta=lgca.props['theta'][cell]):
                 # print 'switch to rest', cell
                 rest[np.where(rest == 0)[0][0]] = cell
                 vel[np.where(vel == cell)[0][0]] = 0
 
         for cell in can_switch_to_vel:
-            if npr.random() < 1 - tanh_switch(rho, kappa=lgca.props['kappa'][cell], theta=lgca.props['theta'][cell]):
+            if lgca.rng.random() < 1 - tanh_switch(rho, kappa=lgca.props['kappa'][cell], theta=lgca.props['theta'][cell]):
                 # print 'switch to vel', cell
                 vel[np.where(vel == 0)[0][0]] = cell
                 rest[np.where(rest == cell)[0][0]] = 0
 
         # cells in rest channels can proliferate
-        can_proliferate = npr.permutation(rest[rest > 0])[:(rest == 0).sum()]
+        can_proliferate = lgca.rng.permutation(rest[rest > 0])[:(rest == 0).sum()]
         for cell in can_proliferate:
-            if npr.random() < lgca.interaction_params['r_b']:
+            if lgca.rng.random() < lgca.interaction_params['r_b']:
                 lgca.maxlabel += 1
                 rest[np.where(rest == 0)[0][0]] = lgca.maxlabel
                 kappa = lgca.props['kappa'][cell]
                 if lgca.interaction_params['kappa_std'] == 0:
                     lgca.props['kappa'].append(kappa)
                 else:
-                    lgca.props['kappa'].append(npr.normal(loc=kappa, scale=lgca.interaction_params['kappa_std']))
+                    lgca.props['kappa'].append(lgca.rng.normal(loc=kappa, scale=lgca.interaction_params['kappa_std']))
                 theta = lgca.props['theta'][cell]
                 if lgca.interaction_params['theta_std'] == 0:
                     lgca.props['theta'].append(theta)
                 else:
-                    lgca.props['theta'].append(npr.normal(loc=theta, scale=lgca.interaction_params['theta_std']))
+                    lgca.props['theta'].append(lgca.rng.normal(loc=theta, scale=lgca.interaction_params['theta_std']))
 
-        v_channels = npr.permutation(vel)
-        r_channels = npr.permutation(rest)
+        v_channels = lgca.rng.permutation(vel)
+        r_channels = lgca.rng.permutation(rest)
         node = np.hstack((v_channels, r_channels))
         lgca.nodes[coord] = node
 
@@ -312,7 +312,7 @@ def go_and_grow_mutations(lgca):
     The LGCA object and its property lists are modified in place.
     """
     # dying process
-    dying = (npr.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
+    dying = (lgca.rng.random(size=lgca.nodes.shape) < lgca.interaction_params['r_d']) & lgca.occupied
     lgca.nodes[dying] = 0
     lgca.update_dynamic_fields()
 
@@ -329,12 +329,12 @@ def go_and_grow_mutations(lgca):
         else:
             # rb is constant
             r_bs = lgca.interaction_params['r_b'] * node.astype(bool)
-        proliferating = npr.random(lgca.K) < r_bs
+        proliferating = lgca.rng.random(lgca.K) < r_bs
         n_p = proliferating.sum()
         if n_p == 0:
             continue
         # pick a random channel for each proliferating cell
-        targetchannels = npr.choice(lgca.K, size=n_p, replace=False)
+        targetchannels = lgca.rng.choice(lgca.K, size=n_p, replace=False)
         for i, label in enumerate(node[proliferating]):
             # If the picked channel is empty, place the daughter cell there
             ind = targetchannels[i]
@@ -345,7 +345,7 @@ def go_and_grow_mutations(lgca):
                 # family: lgca.props['family'][label]
                 fam = lgca.props['family'][label]
 
-                mutation = npr.random() < lgca.interaction_params['r_m']
+                mutation = lgca.rng.random() < lgca.interaction_params['r_m']
                 if mutation:
                     # add new family from the mother's family
                     # this increases lgca.maxfamily +=1 and manages the family tree

--- a/lgca/interactions.py
+++ b/lgca/interactions.py
@@ -29,11 +29,12 @@ def disarrange(a: np.ndarray, axis=-1):
            last axis.
     """
     b = a.swapaxes(axis, -1)
-    # Shuffle `b` in-place along the last axis.  `b` is a view of `a`,
+    # Shuffle `b` in-place along the last axis. `b` is a view of `a`,
     # so `a` is shuffled in place, too.
+    rng = npr.default_rng()
     shp = b.shape[:-1]
     for ndx in np.ndindex(shp):
-        np.random.shuffle(b[ndx])
+        rng.shuffle(b[ndx])
     return
 
 

--- a/lgca/lgca_square.py
+++ b/lgca/lgca_square.py
@@ -443,7 +443,7 @@ class LGCA_Square(SquarePlotMixin, LGCA_base):
         self._apply_rbcx()
 
         if hasattr(self, 'inflow'):
-            self.nodes[self.r_int, ...] = npr.random(self.nodes[0].shape) < self.inflow
+            self.nodes[self.r_int, ...] = self.rng.random(self.nodes[0].shape) < self.inflow
         else:
             self.nodes[self.r_int, ...] = 1
 


### PR DESCRIPTION
## Summary
- use LGCA RNG instead of module-level numpy random functions
- update `disarrange` helper to use a Generator instance

## Testing Done
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685055c0b2b48333a5d3b3bcdfbf26e6